### PR TITLE
Add retry for replaceClasses

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "lint": "eslint ./src ./test ./test_system --fix",
     "prepare": "husky",
     "postversion": "npm run doc:generate",
-    "test": "nyc mocha 'test/**/*.test.*'",
-    "test:only": "nyc mocha",
+    "test": "nyc mocha --timeout 10000 'test/**/*.test.*'",
+    "test:only": "nyc mocha --timeout 10000",
     "test:system:init": "cp test_system/.env .env",
     "test:system": "mocha --timeout 30000 'test_system/**/*.test.*'"
   },

--- a/test/services/salesforce/deploy.test.ts
+++ b/test/services/salesforce/deploy.test.ts
@@ -22,6 +22,81 @@ describe('Deploy', () => {
     ]);
   });
 
+  it('should handle query failure with retry', async () => {
+    const tooling = new FakeTooling([], {
+      query: 1,
+      create: 0,
+      delete: 0,
+    });
+    const connection = await createConnection(tooling);
+
+    await connection.replaceClasses(new Map([['Foo', 'public class Foo {}']]));
+    expect(tooling.deletedIds).to.deep.equal([]);
+    expect(tooling.created).to.deep.equal([
+      {
+        name: 'Foo',
+        body: 'public class Foo {}',
+      },
+    ]);
+  });
+
+  it('should handle create failure with retry', async () => {
+    const tooling = new FakeTooling([], {
+      query: 0,
+      create: 1,
+      delete: 0,
+    });
+    const connection = await createConnection(tooling);
+
+    await connection.replaceClasses(new Map([['Foo', 'public class Foo {}']]));
+    expect(tooling.deletedIds).to.deep.equal([]);
+    expect(tooling.created).to.deep.equal([
+      {
+        name: 'Foo',
+        body: 'public class Foo {}',
+      },
+    ]);
+  });
+
+  it('should handle delete failure with retry', async () => {
+    const tooling = new FakeTooling([], {
+      query: 0,
+      create: 0,
+      delete: 1,
+    });
+    const connection = await createConnection(tooling);
+
+    await connection.replaceClasses(new Map([['Foo', 'public class Foo {}']]));
+    expect(tooling.deletedIds).to.deep.equal([]);
+    expect(tooling.created).to.deep.equal([
+      {
+        name: 'Foo',
+        body: 'public class Foo {}',
+      },
+    ]);
+  });
+
+  it('should error on too many failures', async () => {
+    const tooling = new FakeTooling([], {
+      query: 0,
+      create: 4,
+      delete: 0,
+    });
+    const connection = await createConnection(tooling);
+
+    try {
+      await connection.replaceClasses(
+        new Map([['Foo', 'public class Foo {}']])
+      );
+      expect.fail();
+    } catch (e) {
+      expect(e).to.be.instanceof(Error);
+      expect((e as Error).message).to.contains(
+        'Failed to execute function after 3 attempts.'
+      );
+    }
+  });
+
   it('should create multiple new classes', async () => {
     const tooling = new FakeTooling([]);
     const connection = await createConnection(tooling);
@@ -65,17 +140,32 @@ interface NameAndBody {
   body: string;
 }
 
+interface FailureCounts {
+  query: number;
+  create: number;
+  delete: number;
+}
+
 class FakeTooling {
   public deletedIds: string[] = [];
   public created: NameAndBody[] = [];
   private existingClassIds: string[];
+  private failureCounts: FailureCounts;
 
-  constructor(existingClassIds: string[]) {
+  constructor(
+    existingClassIds: string[],
+    failureCounts: FailureCounts = { query: 0, create: 0, delete: 0 }
+  ) {
     this.existingClassIds = existingClassIds;
+    this.failureCounts = failureCounts;
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async query(soql: string): Promise<any> {
+    if (this.failureCounts.query > 0) {
+      this.failureCounts.query -= 1;
+      throw new Error('Query failure');
+    }
     const ids = this.existingClassIds.map(id => {
       return {
         Id: id,
@@ -90,10 +180,20 @@ class FakeTooling {
   }
 
   async create(nameAndBody: NameAndBody): Promise<void> {
+    if (this.failureCounts.create > 0) {
+      this.failureCounts.create -= 1;
+      throw new Error('Create failure');
+    }
+
     this.created.push(nameAndBody);
   }
 
   async delete(id: string): Promise<void> {
+    if (this.failureCounts.delete > 0) {
+      this.failureCounts.delete -= 1;
+      throw new Error('Delete failure');
+    }
+
     this.deletedIds.push(id);
   }
 }

--- a/test/services/salesforce/deploy.test.ts
+++ b/test/services/salesforce/deploy.test.ts
@@ -95,7 +95,6 @@ describe('Deploy', () => {
         'Failed to execute function after 3 attempts.'
       );
     }
-    return Promise.resolve();
   });
 
   it('should create multiple new classes', async () => {

--- a/test/services/salesforce/deploy.test.ts
+++ b/test/services/salesforce/deploy.test.ts
@@ -95,6 +95,7 @@ describe('Deploy', () => {
         'Failed to execute function after 3 attempts.'
       );
     }
+    return Promise.resolve();
   });
 
   it('should create multiple new classes', async () => {


### PR DESCRIPTION
I was tempted just to wrap all of replaceClasses but thought would be better to wrap just the query/create/delete calls individually just in case there were a lot of classes being handled that we didn't want to start again with. Also means logic issues outside of the tooling calls won't retry with unexpected consequences which I guess is preferrable, not that there is much code outside the calls in this case.