### PR TITLE
Add LWS (Lightning Web Security) Tracking to UI Test Results & Alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Benchmarker - Changelog
 
+## 7.0.0
+
+- Add LWS (Lightning Web Security) Tracking to UI Test Results & Alerts.
+
 ## 6.1.0
 
 - UI performance alerts are now suppressed if the same test suite and individual test have already triggered an alert within the last 3 days.
@@ -45,6 +49,7 @@
 ### Added
 
 - New property on `TestStepDescription`, `additionalData`. Provide custom string information to link to results.
+
   - Stored against `flowName`, `action` and `product` of the test.
   - To set it use `createApexExecutionTestStepFlow(connection, path, { flowName, action, additionalData })`.
 
@@ -80,6 +85,7 @@
 ### Added
 
 - New alerts config for global and per test usage. Used for reporting on degradations over time.
+
   - Configure global behaviour with a JSON file, or per test with new parameter on `TransactionProcess.executeTestStep`.
   - See [the documentation on alerts](./docs/user/alerts.md) for more details.
 

--- a/db/migrations/V7__add_lws_enabled_column.sql
+++ b/db/migrations/V7__add_lws_enabled_column.sql
@@ -1,0 +1,2 @@
+ALTER TABLE performance.ui_test_result add column IF NOT EXISTS lws_enabled boolean NOT NULL DEFAULT false;
+ALTER TABLE performance.ui_alert add column IF NOT EXISTS lws_enabled boolean NOT NULL DEFAULT false;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@apexdevtools/benchmarker",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@apexdevtools/benchmarker",
-      "version": "6.1.0",
+      "version": "7.0.0",
       "dependencies": {
         "@jsforce/jsforce-node": "3.2.0",
         "@salesforce/core": "7.3.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apexdevtools/benchmarker",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Benchmarks performance of processes on Salesforce Orgs",
   "author": {
     "name": "Apex Dev Tools Team",

--- a/src/database/entity/uiAlert.ts
+++ b/src/database/entity/uiAlert.ts
@@ -28,6 +28,9 @@ export class UiAlert extends PerformanceBaseEntity {
   @Column('integer', { nullable: true, name: 'component_load_time_degraded' })
   public componentLoadTimeDegraded = DEFAULT_NUMERIC_VALUE;
 
+  @Column('boolean', { name: 'lws_enabled', default: false })
+  public lwsEnabled = false;
+
   public constructor() {
     super();
   }

--- a/src/database/entity/uiAlert.ts
+++ b/src/database/entity/uiAlert.ts
@@ -28,6 +28,9 @@ export class UiAlert extends PerformanceBaseEntity {
   @Column('integer', { nullable: true, name: 'component_load_time_degraded' })
   public componentLoadTimeDegraded = DEFAULT_NUMERIC_VALUE;
 
+  @Column('boolean', { nullable: false, default: false, name: 'lws_enabled' })
+  public lwsEnabled: boolean = false;
+
   public constructor() {
     super();
   }

--- a/src/database/entity/uiTestResult.ts
+++ b/src/database/entity/uiTestResult.ts
@@ -28,6 +28,9 @@ export class UiTestResult extends PerformanceBaseEntity {
   @Column('integer', { nullable: true, name: 'overall_load_time' })
   public overallLoadTime = DEFAULT_NUMERIC_VALUE;
 
+  @Column('boolean', { nullable: false, default: false, name: 'lws_enabled' })
+  public lwsEnabled: boolean = false;
+
   public constructor() {
     super();
   }

--- a/src/database/entity/uiTestResult.ts
+++ b/src/database/entity/uiTestResult.ts
@@ -28,6 +28,9 @@ export class UiTestResult extends PerformanceBaseEntity {
   @Column('integer', { nullable: true, name: 'overall_load_time' })
   public overallLoadTime = DEFAULT_NUMERIC_VALUE;
 
+  @Column('boolean', { name: 'lws_enabled', default: false })
+  public lwsEnabled = false;
+
   public constructor() {
     super();
   }

--- a/src/database/uiAlertInfo.ts
+++ b/src/database/uiAlertInfo.ts
@@ -73,7 +73,7 @@ export async function getAverageLimitValuesFromDB(
   const connection = await getConnection();
 
   const countResultMap = await fetchHistoryCounts(connection);
-  if (countResultMap === null) {
+  if (!countResultMap || Object.keys(countResultMap).length === 0) {
     return {};
   }
 

--- a/src/database/uiAlertInfo.ts
+++ b/src/database/uiAlertInfo.ts
@@ -72,13 +72,11 @@ export async function getAverageLimitValuesFromDB(
 ) {
   const connection = await getConnection();
 
-  // Step 1: Find which test+lws combinations have enough history (>15 days old)
   const countResultMap = await fetchHistoryCounts(connection);
   if (countResultMap === null) {
     return {};
   }
 
-  // Step 2: Filter to only pairs that have historical data to compare against
   const pairsWithHistory = suiteAndTestNamePairs.filter(pair => {
     const countKey = `${pair.individualTestName}${KEY_DELIMITER}${pair.lwsEnabled}`;
     return countResultMap[countKey]?.count_older_than_15_days > 0;
@@ -88,7 +86,6 @@ export async function getAverageLimitValuesFromDB(
     return {};
   }
 
-  // Step 3: Fetch rolling averages for the qualifying pairs
   return fetchRollingAverages(connection, pairsWithHistory);
 }
 

--- a/src/database/uiAlertInfo.ts
+++ b/src/database/uiAlertInfo.ts
@@ -78,7 +78,11 @@ export async function getAverageLimitValuesFromDB(
   }
 
   const pairsWithHistory = suiteAndTestNamePairs.filter(pair => {
-    const countKey = `${pair.individualTestName}${KEY_DELIMITER}${pair.lwsEnabled}`;
+    const countKey = buildKey(
+      pair.testSuiteName,
+      pair.individualTestName,
+      pair.lwsEnabled
+    );
     return countResultMap[countKey]?.count_older_than_15_days > 0;
   });
 
@@ -93,17 +97,21 @@ async function fetchHistoryCounts(
   connection: any
 ): Promise<{ [key: string]: { count_older_than_15_days: number } } | null> {
   const countQuery = `
-    SELECT individual_test_name, lws_enabled,
+    SELECT individual_test_name, lws_enabled, test_suite_name,
       COUNT(create_date_time) AS count_older_than_15_days
     FROM performance.ui_test_result
     WHERE create_date_time <= CURRENT_DATE - INTERVAL '15 days'
-    GROUP BY individual_test_name, lws_enabled
+    GROUP BY individual_test_name, lws_enabled, test_suite_name
   `;
   try {
     const rows = await connection.query(countQuery);
     const map: { [key: string]: { count_older_than_15_days: number } } = {};
     for (const row of rows) {
-      const key = `${row.individual_test_name}${KEY_DELIMITER}${row.lws_enabled}`;
+      const key = buildKey(
+        row.test_suite_name,
+        row.individual_test_name,
+        row.lws_enabled
+      );
       map[key] = { count_older_than_15_days: row.count_older_than_15_days };
     }
     return map;

--- a/src/database/uiAlertInfo.ts
+++ b/src/database/uiAlertInfo.ts
@@ -6,6 +6,47 @@ import { getConnection } from './connection';
 import { UiAlert } from './entity/uiAlert';
 import { UiTestResult } from './entity/uiTestResult';
 
+export type SuiteTestLwsPair = {
+  testSuiteName: string;
+  individualTestName: string;
+  lwsEnabled: boolean;
+};
+
+const KEY_DELIMITER = '_';
+
+export function buildKey(
+  suiteName: string,
+  testName: string,
+  lwsEnabled: boolean
+): string {
+  return `${suiteName}${KEY_DELIMITER}${testName}${KEY_DELIMITER}${lwsEnabled}`;
+}
+
+/**
+ * Builds a parameterized SQL IN clause for (test_suite_name, individual_test_name, lws_enabled) tuples.
+ * Returns the SQL fragment and a flat array of parameter values.
+ *
+ * Example output for 2 pairs starting at offset 0:
+ *   sql:    "($1, $2, $3), ($4, $5, $6)"
+ *   params: ["suite1", "test1", false, "suite2", "test2", true]
+ */
+function buildTupleParams(
+  pairs: SuiteTestLwsPair[],
+  startIndex = 1
+): { sql: string; params: (string | boolean)[] } {
+  const params: (string | boolean)[] = [];
+  const tuples: string[] = [];
+  let idx = startIndex;
+
+  for (const pair of pairs) {
+    tuples.push(`($${idx}, $${idx + 1}, $${idx + 2})`);
+    params.push(pair.testSuiteName, pair.individualTestName, pair.lwsEnabled);
+    idx += 3;
+  }
+
+  return { sql: tuples.join(', '), params };
+}
+
 export async function saveAlerts(
   testResultsDB: UiTestResult[],
   alerts: UiAlert[]
@@ -27,57 +68,69 @@ export async function saveAlerts(
 }
 
 export async function getAverageLimitValuesFromDB(
-  suiteAndTestNamePairs: { testSuiteName: string; individualTestName: string }[]
+  suiteAndTestNamePairs: SuiteTestLwsPair[]
 ) {
   const connection = await getConnection();
 
-  const countQuery = `
-    SELECT individual_test_name,
-      	COUNT(create_date_time) AS count_older_than_15_days
-      FROM performance.ui_test_result
-      WHERE create_date_time <= CURRENT_DATE - INTERVAL '15 days'
-      GROUP BY individual_test_name
-  `;
+  // Step 1: Find which test+lws combinations have enough history (>15 days old)
+  const countResultMap = await fetchHistoryCounts(connection);
+  if (countResultMap === null) {
+    return {};
+  }
 
-  const countResultMap: {
-    [key: string]: { count_older_than_15_days: number };
-  } = {};
+  // Step 2: Filter to only pairs that have historical data to compare against
+  const pairsWithHistory = suiteAndTestNamePairs.filter(pair => {
+    const countKey = `${pair.individualTestName}${KEY_DELIMITER}${pair.lwsEnabled}`;
+    return countResultMap[countKey]?.count_older_than_15_days > 0;
+  });
+
+  if (pairsWithHistory.length === 0) {
+    return {};
+  }
+
+  // Step 3: Fetch rolling averages for the qualifying pairs
+  return fetchRollingAverages(connection, pairsWithHistory);
+}
+
+async function fetchHistoryCounts(
+  connection: any
+): Promise<{ [key: string]: { count_older_than_15_days: number } } | null> {
+  const countQuery = `
+    SELECT individual_test_name, lws_enabled,
+      COUNT(create_date_time) AS count_older_than_15_days
+    FROM performance.ui_test_result
+    WHERE create_date_time <= CURRENT_DATE - INTERVAL '15 days'
+    GROUP BY individual_test_name, lws_enabled
+  `;
   try {
-    const countResult = await connection.query(countQuery);
-    countResult.forEach(
-      (row: {
-        individual_test_name: string;
-        count_older_than_15_days: number;
-      }) => {
-        countResultMap[row.individual_test_name] = {
-          count_older_than_15_days: row.count_older_than_15_days,
-        };
-      }
-    );
+    const rows = await connection.query(countQuery);
+    const map: { [key: string]: { count_older_than_15_days: number } } = {};
+    for (const row of rows) {
+      const key = `${row.individual_test_name}${KEY_DELIMITER}${row.lws_enabled}`;
+      map[key] = { count_older_than_15_days: row.count_older_than_15_days };
+    }
+    return map;
   } catch (error) {
     console.error('Error in fetching the count values: ', error);
     return {};
   }
+}
 
-  const suiteAndTestNameConditions = suiteAndTestNamePairs
-    .flatMap(pair => {
-      if (
-        countResultMap[pair.individualTestName]?.count_older_than_15_days > 0
-      ) {
-        return [`('${pair.testSuiteName}', '${pair.individualTestName}')`];
-      }
-      return [];
-    })
-    .join(', ');
-
-  if (suiteAndTestNameConditions.length === 0) {
-    return {};
-  }
-
+async function fetchRollingAverages(
+  connection: any,
+  pairs: SuiteTestLwsPair[]
+): Promise<{
+  [key: string]: {
+    avg_load_time_past_5_days: number;
+    avg_load_time_6_to_15_days_ago: number;
+  };
+}> {
+  const { sql: tuplesSql, params } = buildTupleParams(pairs);
   const avgQuery = `
     SELECT 
       individual_test_name,
       test_suite_name,
+      lws_enabled,
       ROUND(AVG(CASE 
           WHEN create_date_time >= CURRENT_DATE - INTERVAL '5 days' 
           THEN component_load_time 
@@ -91,11 +144,10 @@ export async function getAverageLimitValuesFromDB(
       END)::numeric, 0) AS avg_load_time_6_to_15_days_ago
     FROM performance.ui_test_result
     WHERE create_date_time >= CURRENT_DATE - INTERVAL '15 days'
-      AND (test_suite_name, individual_test_name) IN (${suiteAndTestNameConditions})
-    GROUP BY individual_test_name, test_suite_name
+    AND (test_suite_name, individual_test_name, lws_enabled) IN (${tuplesSql})
+    GROUP BY individual_test_name, test_suite_name, lws_enabled
     ORDER BY individual_test_name;
   `;
-
   const resultsMap: {
     [key: string]: {
       avg_load_time_past_5_days: number;
@@ -104,25 +156,18 @@ export async function getAverageLimitValuesFromDB(
   } = {};
 
   try {
-    const result = await connection.query(avgQuery);
-
-    // Populate the results map
-    result.forEach(
-      (row: {
-        test_suite_name: string;
-        individual_test_name: string;
-        avg_load_time_past_5_days: number;
-        avg_load_time_6_to_15_days_ago: number;
-      }) => {
-        const key = `${row.test_suite_name}_${row.individual_test_name}`;
-        resultsMap[key] = {
-          avg_load_time_past_5_days: row.avg_load_time_past_5_days ?? 0,
-          avg_load_time_6_to_15_days_ago:
-            row.avg_load_time_6_to_15_days_ago ?? 0,
-        };
-      }
-    );
-
+    const rows = await connection.query(avgQuery, params);
+    for (const row of rows) {
+      const key = buildKey(
+        row.test_suite_name,
+        row.individual_test_name,
+        row.lws_enabled
+      );
+      resultsMap[key] = {
+        avg_load_time_past_5_days: row.avg_load_time_past_5_days ?? 0,
+        avg_load_time_6_to_15_days_ago: row.avg_load_time_6_to_15_days_ago ?? 0,
+      };
+    }
     return resultsMap;
   } catch (error) {
     console.error('Error in fetching the average values: ', error);

--- a/src/database/uiAlertInfo.ts
+++ b/src/database/uiAlertInfo.ts
@@ -181,31 +181,22 @@ async function fetchRollingAverages(
 }
 
 export async function checkRecentUiAlerts(
-  suiteAndTestNamePairs: {
-    testSuiteName: string;
-    individualTestName: string;
-    lwsEnabled: boolean;
-  }[]
+  suiteAndTestNamePairs: SuiteTestLwsPair[]
 ) {
   const connection = await getConnection();
-  const suiteAndTestNameConditions = suiteAndTestNamePairs
-    .map(
-      pair =>
-        `('${pair.testSuiteName}', '${pair.individualTestName}', '${pair.lwsEnabled}')`
-    )
-    .join(', ');
+  const { sql: tuplesSql, params } = buildTupleParams(suiteAndTestNamePairs);
 
   const query = `
     SELECT test_suite_name, individual_test_name, lws_enabled
     FROM performance.ui_alert
     WHERE create_date_time >= CURRENT_DATE - INTERVAL '3 days'
-      AND (test_suite_name, individual_test_name, lws_enabled) IN (${suiteAndTestNameConditions})
+      AND (test_suite_name, individual_test_name, lws_enabled) IN (${tuplesSql})
   `;
 
   const existingAlerts = new Set<string>();
 
   try {
-    const result = await connection.query(query);
+    const result = await connection.query(query, params);
     result.forEach(
       (row: {
         test_suite_name: string;

--- a/src/database/uiAlertInfo.ts
+++ b/src/database/uiAlertInfo.ts
@@ -14,7 +14,8 @@ export async function saveAlerts(
     const match = testResultsDB.find(
       result =>
         result.testSuiteName === alert.testSuiteName &&
-        result.individualTestName === alert.individualTestName
+        result.individualTestName === alert.individualTestName &&
+        result.lwsEnabled === alert.lwsEnabled
     );
     if (match) {
       alert.uiTestResultId = match.id;

--- a/src/database/uiAlertInfo.ts
+++ b/src/database/uiAlertInfo.ts
@@ -130,20 +130,34 @@ export async function getAverageLimitValuesFromDB(
   }
 }
 
+export function buildKey(
+  testSuiteName: string,
+  individualTestName: string,
+  lwsEnabled: boolean
+): string {
+  return `${testSuiteName}_${individualTestName}_${lwsEnabled}`;
+}
+
 export async function checkRecentUiAlerts(
-  suiteAndTestNamePairs: { testSuiteName: string; individualTestName: string }[]
+  suiteAndTestNamePairs: {
+    testSuiteName: string;
+    individualTestName: string;
+    lwsEnabled: boolean;
+  }[]
 ) {
   const connection = await getConnection();
-
   const suiteAndTestNameConditions = suiteAndTestNamePairs
-    .map(pair => `('${pair.testSuiteName}', '${pair.individualTestName}')`)
+    .map(
+      pair =>
+        `('${pair.testSuiteName}', '${pair.individualTestName}', '${pair.lwsEnabled}')`
+    )
     .join(', ');
 
   const query = `
-    SELECT test_suite_name, individual_test_name
+    SELECT test_suite_name, individual_test_name, lws_enabled
     FROM performance.ui_alert
     WHERE create_date_time >= CURRENT_DATE - INTERVAL '3 days'
-      AND (test_suite_name, individual_test_name) IN (${suiteAndTestNameConditions})
+      AND (test_suite_name, individual_test_name, lws_enabled) IN (${suiteAndTestNameConditions})
   `;
 
   const existingAlerts = new Set<string>();
@@ -151,9 +165,17 @@ export async function checkRecentUiAlerts(
   try {
     const result = await connection.query(query);
     result.forEach(
-      (row: { test_suite_name: string; individual_test_name: string }) => {
+      (row: {
+        test_suite_name: string;
+        individual_test_name: string;
+        lws_enabled: boolean;
+      }) => {
         existingAlerts.add(
-          `${row.test_suite_name}_${row.individual_test_name}`
+          buildKey(
+            row.test_suite_name,
+            row.individual_test_name,
+            row.lws_enabled
+          )
         );
       }
     );

--- a/src/database/uiTestResult.ts
+++ b/src/database/uiTestResult.ts
@@ -49,6 +49,7 @@ export interface UiTestResultDTO {
 export interface UiTestResultFilterOptions {
   testSuiteName?: string;
   individualTestName?: string;
+  lwsEnabled?: boolean;
 }
 
 /**
@@ -112,6 +113,9 @@ export async function loadUiTestResults(
     }
     if (filterOptions.individualTestName !== undefined) {
       whereClause.individualTestName = filterOptions.individualTestName;
+    }
+    if (filterOptions.lwsEnabled !== undefined) {
+      whereClause.lwsEnabled = filterOptions.lwsEnabled;
     }
   }
 

--- a/src/database/uiTestResult.ts
+++ b/src/database/uiTestResult.ts
@@ -39,6 +39,7 @@ export interface UiTestResultDTO {
   componentLoadTime?: number;
   salesforceLoadTime?: number;
   overallLoadTime: number;
+  lwsEnabled?: boolean;
   alertInfo?: UiAlertInfo;
 }
 
@@ -61,6 +62,7 @@ function dtoToEntity(dto: UiTestResultDTO): UiTestResult {
   entity.componentLoadTime = dto.componentLoadTime || 0;
   entity.salesforceLoadTime = dto.salesforceLoadTime || 0;
   entity.overallLoadTime = dto.overallLoadTime;
+  entity.lwsEnabled = dto.lwsEnabled ?? false;
 
   return entity;
 }
@@ -75,6 +77,7 @@ function entityToDto(entity: UiTestResult): UiTestResultDTO {
     componentLoadTime: entity.componentLoadTime,
     salesforceLoadTime: entity.salesforceLoadTime,
     overallLoadTime: entity.overallLoadTime,
+    lwsEnabled: entity.lwsEnabled,
   };
 }
 

--- a/src/services/result/uiAlert.ts
+++ b/src/services/result/uiAlert.ts
@@ -8,6 +8,7 @@ import {
   getCriticalComponentLoadThreshold,
 } from '../../shared/env';
 import {
+  buildKey,
   getAverageLimitValuesFromDB,
   checkRecentUiAlerts,
 } from '../../database/uiAlertInfo';
@@ -32,13 +33,20 @@ export async function generateValidAlerts(
     const suiteAndTestNamePairs = needToStoreAlert.map(result => ({
       testSuiteName: result.testSuiteName,
       individualTestName: result.individualTestName,
+      lwsEnabled: result.lwsEnabled ?? false,
     }));
 
     const existingAlerts = await checkRecentUiAlerts(suiteAndTestNamePairs);
 
     const alertsToProcess = needToStoreAlert.filter(
       item =>
-        !existingAlerts.has(`${item.testSuiteName}_${item.individualTestName}`)
+        !existingAlerts.has(
+          buildKey(
+            item.testSuiteName,
+            item.individualTestName,
+            item.lwsEnabled ?? false
+          )
+        )
     );
 
     if (alertsToProcess.length === 0) {

--- a/src/services/result/uiAlert.ts
+++ b/src/services/result/uiAlert.ts
@@ -87,9 +87,14 @@ async function addAlertByComparingAvg(
   const alert: UiAlert = new UiAlert();
   alert.testSuiteName = output.testSuiteName;
   alert.individualTestName = output.individualTestName;
+  alert.lwsEnabled = output.lwsEnabled ?? false;
 
   // Construct the key for the current individualTestName and testSuiteName
-  const key = `${output.testSuiteName}_${output.individualTestName}`;
+  const key = buildKey(
+    output.testSuiteName,
+    output.individualTestName,
+    output.lwsEnabled ?? false
+  );
 
   const averageResults = preFetchedAverages[key];
 

--- a/src/services/result/uiAlert.ts
+++ b/src/services/result/uiAlert.ts
@@ -11,7 +11,6 @@ import {
   buildKey,
   getAverageLimitValuesFromDB,
   checkRecentUiAlerts,
-  buildKey,
 } from '../../database/uiAlertInfo';
 import { UiAlert } from '../../database/entity/uiAlert';
 import { UiTestResultDTO } from '../../database/uiTestResult';

--- a/src/services/result/uiAlert.ts
+++ b/src/services/result/uiAlert.ts
@@ -32,6 +32,7 @@ export async function generateValidAlerts(
     const suiteAndTestNamePairs = needToStoreAlert.map(result => ({
       testSuiteName: result.testSuiteName,
       individualTestName: result.individualTestName,
+      lwsEnabled: result.lwsEnabled ?? false,
     }));
 
     const existingAlerts = await checkRecentUiAlerts(suiteAndTestNamePairs);

--- a/src/services/result/uiAlert.ts
+++ b/src/services/result/uiAlert.ts
@@ -98,9 +98,10 @@ async function addAlertByComparingAvg(
     ?.uiAlertThresholds
     ? output.alertInfo.uiAlertThresholds.componentLoadTimeThresholdCritical
     : Number(getCriticalComponentLoadThreshold());
-  const componentLoadThresholdDegraded =
+  const componentLoadThresholdDegraded = Math.abs(
     averageResults.avg_load_time_past_5_days -
-    averageResults.avg_load_time_6_to_15_days_ago;
+      averageResults.avg_load_time_6_to_15_days_ago
+  );
 
   if (
     componentLoadThresholdDegraded >= normalComponentLoadThreshold &&

--- a/src/services/result/uiAlert.ts
+++ b/src/services/result/uiAlert.ts
@@ -10,6 +10,7 @@ import {
 import {
   getAverageLimitValuesFromDB,
   checkRecentUiAlerts,
+  buildKey,
 } from '../../database/uiAlertInfo';
 import { UiAlert } from '../../database/entity/uiAlert';
 import { UiTestResultDTO } from '../../database/uiTestResult';
@@ -39,7 +40,13 @@ export async function generateValidAlerts(
 
     const alertsToProcess = needToStoreAlert.filter(
       item =>
-        !existingAlerts.has(`${item.testSuiteName}_${item.individualTestName}`)
+        !existingAlerts.has(
+          buildKey(
+            item.testSuiteName,
+            item.individualTestName,
+            item.lwsEnabled ?? false
+          )
+        )
     );
 
     if (alertsToProcess.length === 0) {

--- a/src/services/result/uiAlert.ts
+++ b/src/services/result/uiAlert.ts
@@ -89,7 +89,7 @@ async function addAlertByComparingAvg(
   alert.individualTestName = output.individualTestName;
   alert.lwsEnabled = output.lwsEnabled ?? false;
 
-  // Construct the key for the current individualTestName and testSuiteName
+  // Construct the key for the current individualTestName and testSuiteName and lwsEnabled
   const key = buildKey(
     output.testSuiteName,
     output.individualTestName,

--- a/src/services/result/uiAlert.ts
+++ b/src/services/result/uiAlert.ts
@@ -98,10 +98,9 @@ async function addAlertByComparingAvg(
     ?.uiAlertThresholds
     ? output.alertInfo.uiAlertThresholds.componentLoadTimeThresholdCritical
     : Number(getCriticalComponentLoadThreshold());
-  const componentLoadThresholdDegraded = Math.abs(
+  const componentLoadThresholdDegraded =
     averageResults.avg_load_time_past_5_days -
-      averageResults.avg_load_time_6_to_15_days_ago
-  );
+    averageResults.avg_load_time_6_to_15_days_ago;
 
   if (
     componentLoadThresholdDegraded >= normalComponentLoadThreshold &&

--- a/test/database/uiAlertInfo.test.ts
+++ b/test/database/uiAlertInfo.test.ts
@@ -6,6 +6,8 @@ import {
   getAverageLimitValuesFromDB,
   saveAlerts,
   checkRecentUiAlerts,
+  buildKey,
+  SuiteTestLwsPair,
 } from '../../src/database/uiAlertInfo';
 import * as db from '../../src/database/connection';
 import sinon from 'sinon';
@@ -35,24 +37,28 @@ describe('src/database/uiAlertInfo', () => {
   describe('getAverageLimitValuesFromDB', () => {
     it('should return average limit values for valid data', async () => {
       // Given
-      const suiteAndTestNamePairs = [
+      const suiteAndTestNamePairs: SuiteTestLwsPair[] = [
         {
           testSuiteName: 'testSuiteName1',
           individualTestName: 'individualTestName1',
+          lwsEnabled: false,
         },
         {
           testSuiteName: 'testSuiteName2',
           individualTestName: 'individualTestName2',
+          lwsEnabled: true,
         },
       ];
 
       const mockCountResults = [
         {
           individual_test_name: 'individualTestName1',
+          lws_enabled: false,
           count_older_than_15_days: 20,
         },
         {
           individual_test_name: 'individualTestName2',
+          lws_enabled: true,
           count_older_than_15_days: 18,
         },
       ];
@@ -61,12 +67,14 @@ describe('src/database/uiAlertInfo', () => {
         {
           test_suite_name: 'testSuiteName1',
           individual_test_name: 'individualTestName1',
+          lws_enabled: false,
           avg_load_time_past_5_days: 2000,
           avg_load_time_6_to_15_days_ago: 1500,
         },
         {
           test_suite_name: 'testSuiteName2',
           individual_test_name: 'individualTestName2',
+          lws_enabled: true,
           avg_load_time_past_5_days: 2000,
           avg_load_time_6_to_15_days_ago: 1500,
         },
@@ -82,15 +90,23 @@ describe('src/database/uiAlertInfo', () => {
       expect(mockQuery.calledTwice).to.be.true;
       expect(mockQuery.args[1][0]).to.include('SELECT');
       expect(mockQuery.args[1][0]).to.include(
-        "(test_suite_name, individual_test_name) IN (('testSuiteName1', 'individualTestName1'), ('testSuiteName2', 'individualTestName2'))"
+        '(test_suite_name, individual_test_name, lws_enabled) IN'
       );
+      expect(mockQuery.args[1][1]).to.deep.equal([
+        'testSuiteName1',
+        'individualTestName1',
+        false,
+        'testSuiteName2',
+        'individualTestName2',
+        true,
+      ]);
 
       expect(results).to.deep.equal({
-        testSuiteName1_individualTestName1: {
+        [buildKey('testSuiteName1', 'individualTestName1', false)]: {
           avg_load_time_past_5_days: 2000,
           avg_load_time_6_to_15_days_ago: 1500,
         },
-        testSuiteName2_individualTestName2: {
+        [buildKey('testSuiteName2', 'individualTestName2', true)]: {
           avg_load_time_past_5_days: 2000,
           avg_load_time_6_to_15_days_ago: 1500,
         },
@@ -99,24 +115,28 @@ describe('src/database/uiAlertInfo', () => {
 
     it('should not return average limit values when a test has no results older than 15 days', async () => {
       // Given
-      const suiteAndTestNamePairs = [
+      const suiteAndTestNamePairs: SuiteTestLwsPair[] = [
         {
           testSuiteName: 'testSuiteName1',
           individualTestName: 'individualTestName1',
+          lwsEnabled: false,
         },
         {
           testSuiteName: 'testSuiteName2',
           individualTestName: 'individualTestName2',
+          lwsEnabled: false,
         },
       ];
 
       const mockCountResults = [
         {
           individual_test_name: 'individualTestName1',
+          lws_enabled: false,
           count_older_than_15_days: 20,
         },
         {
           individual_test_name: 'individualTestName2',
+          lws_enabled: false,
           count_older_than_15_days: 0,
         },
       ];
@@ -125,6 +145,7 @@ describe('src/database/uiAlertInfo', () => {
         {
           test_suite_name: 'testSuiteName1',
           individual_test_name: 'individualTestName1',
+          lws_enabled: false,
           avg_load_time_past_5_days: 2000,
           avg_load_time_6_to_15_days_ago: 1500,
         },
@@ -138,13 +159,17 @@ describe('src/database/uiAlertInfo', () => {
 
       // Then
       expect(mockQuery.calledTwice).to.be.true;
-      expect(mockQuery.args[1][0]).to.include('SELECT');
       expect(mockQuery.args[1][0]).to.include(
-        "(test_suite_name, individual_test_name) IN (('testSuiteName1', 'individualTestName1'))"
+        '(test_suite_name, individual_test_name, lws_enabled) IN'
       );
+      expect(mockQuery.args[1][1]).to.deep.equal([
+        'testSuiteName1',
+        'individualTestName1',
+        false,
+      ]);
 
       expect(results).to.deep.equal({
-        testSuiteName1_individualTestName1: {
+        [buildKey('testSuiteName1', 'individualTestName1', false)]: {
           avg_load_time_past_5_days: 2000,
           avg_load_time_6_to_15_days_ago: 1500,
         },
@@ -153,24 +178,28 @@ describe('src/database/uiAlertInfo', () => {
 
     it('should not return average limit values when no results older than 15 days', async () => {
       // Given
-      const suiteAndTestNamePairs = [
+      const suiteAndTestNamePairs: SuiteTestLwsPair[] = [
         {
           testSuiteName: 'testSuiteName1',
           individualTestName: 'individualTestName1',
+          lwsEnabled: false,
         },
         {
           testSuiteName: 'testSuiteName2',
           individualTestName: 'individualTestName2',
+          lwsEnabled: false,
         },
       ];
 
       const mockCountResults = [
         {
           individual_test_name: 'individualTestName1',
+          lws_enabled: false,
           count_older_than_15_days: 0,
         },
         {
           individual_test_name: 'individualTestName2',
+          lws_enabled: false,
           count_older_than_15_days: 0,
         },
       ];
@@ -188,20 +217,23 @@ describe('src/database/uiAlertInfo', () => {
 
     it('should return an empty object when no results are found', async () => {
       // Given
-      const suiteAndTestNamePairs = [
+      const suiteAndTestNamePairs: SuiteTestLwsPair[] = [
         {
           testSuiteName: 'testSuiteName1',
           individualTestName: 'individualTestName1',
+          lwsEnabled: false,
         },
       ];
 
       const mockCountResults = [
         {
           individual_test_name: 'individualTestName1',
+          lws_enabled: false,
           count_older_than_15_days: 20,
         },
         {
           individual_test_name: 'individualTestName2',
+          lws_enabled: false,
           count_older_than_15_days: 18,
         },
       ];
@@ -219,20 +251,23 @@ describe('src/database/uiAlertInfo', () => {
 
     it('should handle missing fields and default them to zero', async () => {
       // Given
-      const suiteAndTestNamePairs = [
+      const suiteAndTestNamePairs: SuiteTestLwsPair[] = [
         {
           testSuiteName: 'testSuiteName1',
           individualTestName: 'individualTestName1',
+          lwsEnabled: false,
         },
       ];
 
       const mockCountResults = [
         {
           individual_test_name: 'individualTestName1',
+          lws_enabled: false,
           count_older_than_15_days: 20,
         },
         {
           individual_test_name: 'individualTestName2',
+          lws_enabled: false,
           count_older_than_15_days: 18,
         },
       ];
@@ -241,6 +276,7 @@ describe('src/database/uiAlertInfo', () => {
         {
           test_suite_name: 'testSuiteName1',
           individual_test_name: 'individualTestName1',
+          lws_enabled: false,
           avg_load_time_past_5_days: null,
           avg_load_time_6_to_15_days_ago: undefined,
         },
@@ -254,7 +290,7 @@ describe('src/database/uiAlertInfo', () => {
 
       // Then
       expect(results).to.deep.equal({
-        testSuiteName1_individualTestName1: {
+        [buildKey('testSuiteName1', 'individualTestName1', false)]: {
           avg_load_time_past_5_days: 0,
           avg_load_time_6_to_15_days_ago: 0,
         },
@@ -263,10 +299,7 @@ describe('src/database/uiAlertInfo', () => {
 
     it('should handle an empty suiteAndTestNamePairs array and return an empty object', async () => {
       // Given
-      const suiteAndTestNamePairs: {
-        testSuiteName: string;
-        individualTestName: string;
-      }[] = [];
+      const suiteAndTestNamePairs: SuiteTestLwsPair[] = [];
 
       // Simulate no results (empty array)
       mockQuery.onFirstCall().resolves([]);
@@ -281,10 +314,11 @@ describe('src/database/uiAlertInfo', () => {
 
     it('should handle errors and return an empty object', async () => {
       // Given
-      const suiteAndTestNamePairs = [
+      const suiteAndTestNamePairs: SuiteTestLwsPair[] = [
         {
           testSuiteName: 'testSuiteName1',
           individualTestName: 'individualTestName1',
+          lwsEnabled: false,
         },
       ];
 
@@ -295,6 +329,81 @@ describe('src/database/uiAlertInfo', () => {
 
       // Then
       expect(results).to.deep.equal({});
+    });
+
+    it('should scope by lwsEnabled so same test with different lwsEnabled values are separate', async () => {
+      // Given
+      const suiteAndTestNamePairs: SuiteTestLwsPair[] = [
+        {
+          testSuiteName: 'suite1',
+          individualTestName: 'test1',
+          lwsEnabled: false,
+        },
+        {
+          testSuiteName: 'suite1',
+          individualTestName: 'test1',
+          lwsEnabled: true,
+        },
+      ];
+
+      const mockCountResults = [
+        {
+          individual_test_name: 'test1',
+          lws_enabled: false,
+          count_older_than_15_days: 10,
+        },
+        {
+          individual_test_name: 'test1',
+          lws_enabled: true,
+          count_older_than_15_days: 5,
+        },
+      ];
+
+      const mockAvgResults = [
+        {
+          test_suite_name: 'suite1',
+          individual_test_name: 'test1',
+          lws_enabled: false,
+          avg_load_time_past_5_days: 1000,
+          avg_load_time_6_to_15_days_ago: 800,
+        },
+        {
+          test_suite_name: 'suite1',
+          individual_test_name: 'test1',
+          lws_enabled: true,
+          avg_load_time_past_5_days: 1200,
+          avg_load_time_6_to_15_days_ago: 900,
+        },
+      ];
+
+      mockQuery.onFirstCall().resolves(mockCountResults);
+      mockQuery.onSecondCall().resolves(mockAvgResults);
+
+      // When
+      const results = await getAverageLimitValuesFromDB(suiteAndTestNamePairs);
+
+      // Then
+      expect(results).to.deep.equal({
+        [buildKey('suite1', 'test1', false)]: {
+          avg_load_time_past_5_days: 1000,
+          avg_load_time_6_to_15_days_ago: 800,
+        },
+        [buildKey('suite1', 'test1', true)]: {
+          avg_load_time_past_5_days: 1200,
+          avg_load_time_6_to_15_days_ago: 900,
+        },
+      });
+    });
+  });
+
+  describe('buildKey', () => {
+    it('should build key with suite name, test name, and lwsEnabled', () => {
+      expect(buildKey('mySuite', 'myTest', false)).to.equal(
+        'mySuite_myTest_false'
+      );
+      expect(buildKey('mySuite', 'myTest', true)).to.equal(
+        'mySuite_myTest_true'
+      );
     });
   });
 

--- a/test/database/uiAlertInfo.test.ts
+++ b/test/database/uiAlertInfo.test.ts
@@ -368,12 +368,24 @@ describe('src/database/uiAlertInfo', () => {
     it('should return a Set of keys for alerts found in the last 3 days', async () => {
       // Given
       const pairs = [
-        { testSuiteName: 'SuiteA', individualTestName: 'Test1' },
-        { testSuiteName: 'SuiteB', individualTestName: 'Test2' },
+        {
+          testSuiteName: 'SuiteA',
+          individualTestName: 'Test1',
+          lwsEnabled: false,
+        },
+        {
+          testSuiteName: 'SuiteB',
+          individualTestName: 'Test2',
+          lwsEnabled: false,
+        },
       ];
 
       const mockDbRows = [
-        { test_suite_name: 'SuiteA', individual_test_name: 'Test1' },
+        {
+          test_suite_name: 'SuiteA',
+          individual_test_name: 'Test1',
+          lws_enabled: false,
+        },
       ];
 
       mockQuery.resolves(mockDbRows);
@@ -387,13 +399,41 @@ describe('src/database/uiAlertInfo', () => {
       const sqlQuery = mockQuery.firstCall.args[0];
       expect(sqlQuery).to.include("INTERVAL '3 days'");
 
-      expect(sqlQuery).to.include("('SuiteA', 'Test1')");
-      expect(sqlQuery).to.include("('SuiteB', 'Test2')");
+      expect(sqlQuery).to.include("('SuiteA', 'Test1', 'false')");
+      expect(sqlQuery).to.include("('SuiteB', 'Test2', 'false')");
 
       expect(result).to.be.instanceOf(Set);
       expect(result.size).to.equal(1);
-      expect(result.has('SuiteA_Test1')).to.be.true;
-      expect(result.has('SuiteB_Test2')).to.be.false;
+      expect(result.has('SuiteA_Test1_false')).to.be.true;
+      expect(result.has('SuiteB_Test2_false')).to.be.false;
+    });
+
+    it('should not suppress an alert for lwsEnabled=false when an alert exists for lwsEnabled=true', async () => {
+      // Given
+      const pairs = [
+        {
+          testSuiteName: 'SuiteA',
+          individualTestName: 'Test1',
+          lwsEnabled: false,
+        },
+      ];
+
+      const mockDbRows = [
+        {
+          test_suite_name: 'SuiteA',
+          individual_test_name: 'Test1',
+          lws_enabled: true,
+        },
+      ];
+
+      mockQuery.resolves(mockDbRows);
+
+      // When
+      const result = await checkRecentUiAlerts(pairs);
+
+      // Then
+      expect(result.has('SuiteA_Test1_true')).to.be.true;
+      expect(result.has('SuiteA_Test1_false')).to.be.false;
     });
 
     it('should return an empty Set if no recent alerts are found', async () => {
@@ -402,7 +442,11 @@ describe('src/database/uiAlertInfo', () => {
 
       // When
       const result = await checkRecentUiAlerts([
-        { testSuiteName: 'SuiteA', individualTestName: 'Test1' },
+        {
+          testSuiteName: 'SuiteA',
+          individualTestName: 'Test1',
+          lwsEnabled: false,
+        },
       ]);
 
       // Then
@@ -417,7 +461,11 @@ describe('src/database/uiAlertInfo', () => {
 
       // When
       const result = await checkRecentUiAlerts([
-        { testSuiteName: 'SuiteA', individualTestName: 'Test1' },
+        {
+          testSuiteName: 'SuiteA',
+          individualTestName: 'Test1',
+          lwsEnabled: false,
+        },
       ]);
 
       // Then

--- a/test/database/uiAlertInfo.test.ts
+++ b/test/database/uiAlertInfo.test.ts
@@ -331,6 +331,72 @@ describe('src/database/uiAlertInfo', () => {
       expect(results).to.deep.equal({});
     });
 
+    it('fetchRollingAverages returns an empty object on error', async () => {
+      // Given
+      const suiteAndTestNamePairs: SuiteTestLwsPair[] = [
+        {
+          testSuiteName: 'suite1',
+          individualTestName: 'test1',
+          lwsEnabled: false,
+        },
+        {
+          testSuiteName: 'suite1',
+          individualTestName: 'test1',
+          lwsEnabled: true,
+        },
+      ];
+
+      const mockCountResults = [
+        {
+          individual_test_name: 'test1',
+          lws_enabled: false,
+          count_older_than_15_days: 10,
+        },
+        {
+          individual_test_name: 'test1',
+          lws_enabled: true,
+          count_older_than_15_days: 5,
+        },
+      ];
+
+      mockQuery.onFirstCall().resolves(mockCountResults);
+      const consoleStub = sinon.stub(console, 'error');
+      mockQuery.rejects(new Error('Connection failed'));
+
+      // When
+      const results = await getAverageLimitValuesFromDB(suiteAndTestNamePairs);
+
+      // Then
+      expect(results).to.deep.equal({});
+      expect(consoleStub).to.have.been.calledWith(
+        sinon.match('Error in fetching the average values: ')
+      );
+
+      consoleStub.restore();
+    });
+
+    it('should return {} when fetchHistoryCounts returns null', async () => {
+      // Given
+      mockQuery.onFirstCall().resolves(null);
+      const suiteAndTestNamePairs: SuiteTestLwsPair[] = [
+        {
+          testSuiteName: 'suite1',
+          individualTestName: 'test1',
+          lwsEnabled: false,
+        },
+        {
+          testSuiteName: 'suite1',
+          individualTestName: 'test1',
+          lwsEnabled: true,
+        },
+      ];
+
+      // When
+      const result = await getAverageLimitValuesFromDB(suiteAndTestNamePairs);
+
+      // Then
+      expect(result).to.deep.equal({});
+    });
     it('should scope by lwsEnabled so same test with different lwsEnabled values are separate', async () => {
       // Given
       const suiteAndTestNamePairs: SuiteTestLwsPair[] = [

--- a/test/database/uiAlertInfo.test.ts
+++ b/test/database/uiAlertInfo.test.ts
@@ -313,12 +313,14 @@ describe('src/database/uiAlertInfo', () => {
       savedEntity.componentLoadTime = 10;
       savedEntity.salesforceLoadTime = 20;
       savedEntity.overallLoadTime = 30;
+      savedEntity.lwsEnabled = false;
 
       const alert: UiAlert = new UiAlert();
       alert.testSuiteName = savedEntity.testSuiteName;
       alert.individualTestName = savedEntity.individualTestName;
       alert.componentLoadTimeDegraded = 2;
       alert.alertType = 'normal';
+      alert.lwsEnabled = false;
       const results = [alert];
 
       // When
@@ -328,6 +330,37 @@ describe('src/database/uiAlertInfo', () => {
       expect(saveStub).to.be.calledOnce;
       expect(savedRecords).to.eql(results);
       expect(savedRecords[0].uiTestResultId).to.equal(1);
+    });
+
+    it('should not link alert to result with different lwsEnabled value', async () => {
+      // Given
+      const saveStub: sinon.SinonStub = sinon.stub().resolvesArg(0);
+      connectionStub.resolves({
+        manager: { save: saveStub },
+      } as unknown as DataSource);
+
+      const savedEntity = new UiTestResult();
+      savedEntity.id = 1;
+      savedEntity.testSuiteName = 'suite';
+      savedEntity.individualTestName = 'test';
+      savedEntity.componentLoadTime = 10;
+      savedEntity.salesforceLoadTime = 20;
+      savedEntity.overallLoadTime = 30;
+      savedEntity.lwsEnabled = false;
+
+      const alert: UiAlert = new UiAlert();
+      alert.testSuiteName = savedEntity.testSuiteName;
+      alert.individualTestName = savedEntity.individualTestName;
+      alert.componentLoadTimeDegraded = 2;
+      alert.alertType = 'normal';
+      alert.lwsEnabled = true;
+
+      // When
+      const savedRecords = await saveAlerts([savedEntity], [alert]);
+
+      // Then
+      expect(saveStub).to.be.calledOnce;
+      expect(savedRecords[0].uiTestResultId).to.not.equal(1);
     });
   });
 

--- a/test/database/uiAlertInfo.test.ts
+++ b/test/database/uiAlertInfo.test.ts
@@ -586,10 +586,18 @@ describe('src/database/uiAlertInfo', () => {
       expect(mockQuery).to.have.been.calledOnce;
 
       const sqlQuery = mockQuery.firstCall.args[0];
+      const queryParams = mockQuery.firstCall.args[1];
       expect(sqlQuery).to.include("INTERVAL '3 days'");
 
-      expect(sqlQuery).to.include("('SuiteA', 'Test1', 'false')");
-      expect(sqlQuery).to.include("('SuiteB', 'Test2', 'false')");
+      expect(sqlQuery).to.include('($1, $2, $3), ($4, $5, $6)');
+      expect(queryParams).to.deep.equal([
+        'SuiteA',
+        'Test1',
+        false,
+        'SuiteB',
+        'Test2',
+        false,
+      ]);
 
       expect(result).to.be.instanceOf(Set);
       expect(result.size).to.equal(1);

--- a/test/database/uiAlertInfo.test.ts
+++ b/test/database/uiAlertInfo.test.ts
@@ -52,11 +52,13 @@ describe('src/database/uiAlertInfo', () => {
 
       const mockCountResults = [
         {
+          test_suite_name: 'testSuiteName1',
           individual_test_name: 'individualTestName1',
           lws_enabled: false,
           count_older_than_15_days: 20,
         },
         {
+          test_suite_name: 'testSuiteName2',
           individual_test_name: 'individualTestName2',
           lws_enabled: true,
           count_older_than_15_days: 18,
@@ -130,11 +132,13 @@ describe('src/database/uiAlertInfo', () => {
 
       const mockCountResults = [
         {
+          test_suite_name: 'testSuiteName1',
           individual_test_name: 'individualTestName1',
           lws_enabled: false,
           count_older_than_15_days: 20,
         },
         {
+          test_suite_name: 'testSuiteName2',
           individual_test_name: 'individualTestName2',
           lws_enabled: false,
           count_older_than_15_days: 0,
@@ -193,11 +197,13 @@ describe('src/database/uiAlertInfo', () => {
 
       const mockCountResults = [
         {
+          test_suite_name: 'testSuiteName1',
           individual_test_name: 'individualTestName1',
           lws_enabled: false,
           count_older_than_15_days: 0,
         },
         {
+          test_suite_name: 'testSuiteName2',
           individual_test_name: 'individualTestName2',
           lws_enabled: false,
           count_older_than_15_days: 0,
@@ -227,11 +233,13 @@ describe('src/database/uiAlertInfo', () => {
 
       const mockCountResults = [
         {
+          test_suite_name: 'testSuiteName1',
           individual_test_name: 'individualTestName1',
           lws_enabled: false,
           count_older_than_15_days: 20,
         },
         {
+          test_suite_name: 'testSuiteName2',
           individual_test_name: 'individualTestName2',
           lws_enabled: false,
           count_older_than_15_days: 18,
@@ -261,11 +269,13 @@ describe('src/database/uiAlertInfo', () => {
 
       const mockCountResults = [
         {
+          test_suite_name: 'testSuiteName1',
           individual_test_name: 'individualTestName1',
           lws_enabled: false,
           count_older_than_15_days: 20,
         },
         {
+          test_suite_name: 'testSuiteName1',
           individual_test_name: 'individualTestName2',
           lws_enabled: false,
           count_older_than_15_days: 18,
@@ -348,11 +358,13 @@ describe('src/database/uiAlertInfo', () => {
 
       const mockCountResults = [
         {
+          test_suite_name: 'suite1',
           individual_test_name: 'test1',
           lws_enabled: false,
           count_older_than_15_days: 10,
         },
         {
+          test_suite_name: 'suite1',
           individual_test_name: 'test1',
           lws_enabled: true,
           count_older_than_15_days: 5,
@@ -414,11 +426,13 @@ describe('src/database/uiAlertInfo', () => {
 
       const mockCountResults = [
         {
+          test_suite_name: 'suite1',
           individual_test_name: 'test1',
           lws_enabled: false,
           count_older_than_15_days: 10,
         },
         {
+          test_suite_name: 'suite1',
           individual_test_name: 'test1',
           lws_enabled: true,
           count_older_than_15_days: 5,

--- a/test/database/uiTestResult.test.ts
+++ b/test/database/uiTestResult.test.ts
@@ -353,36 +353,6 @@ describe('src/database/uiTestResult', () => {
       ]);
     });
 
-    it('should exclude results where lwsEnabled is false when filtering for true', async () => {
-      // Given
-      const findStub = sinon.stub().resolves([]);
-      connectionStub.resolves({
-        manager: { find: findStub },
-      } as unknown as DataSource);
-
-      const filterOptions: UiTestResultFilterOptions = {
-        lwsEnabled: true,
-      };
-
-      // When
-      const result = await loadUiTestResults(filterOptions);
-
-      // Then
-      expect(findStub).to.be.calledWith(UiTestResult, {
-        where: [
-          {
-            createDateTime: sinon.match.any,
-            lwsEnabled: true,
-          },
-        ],
-        order: {
-          createDateTime: 'DESC',
-        },
-      });
-
-      expect(result).to.eql([]);
-    });
-
     it('should not include lwsEnabled in where clause when not provided in filter', async () => {
       // Given
       const entity = new UiTestResult();

--- a/test/database/uiTestResult.test.ts
+++ b/test/database/uiTestResult.test.ts
@@ -124,6 +124,46 @@ describe('src/database/uiTestResult', () => {
       expect(alertInfoStub.args[0][1][0].alertType).to.equal('normal');
     });
 
+    it('should default lwsEnabled to false when not provided in DTO', async () => {
+      // Given
+      const dto: UiTestResultDTO = {
+        testSuiteName: 'suite',
+        individualTestName: 'test',
+        componentLoadTime: 10,
+        salesforceLoadTime: 20,
+        overallLoadTime: 30,
+      };
+
+      const savedEntity = new UiTestResult();
+      savedEntity.id = 1;
+      savedEntity.testSuiteName = 'suite';
+      savedEntity.individualTestName = 'test';
+      savedEntity.componentLoadTime = 10;
+      savedEntity.salesforceLoadTime = 20;
+      savedEntity.overallLoadTime = 30;
+      savedEntity.lwsEnabled = false;
+
+      saveRecordsStub.resolves([savedEntity]);
+      generateValidAlertsStub.resolves([]);
+
+      // When
+      const result = await saveUiTestResult([dto]);
+
+      // Then
+      const entityPassedToSave = saveRecordsStub.args[0][0][0] as UiTestResult;
+      expect(entityPassedToSave.lwsEnabled).to.equal(false);
+      expect(result).to.eql([
+        {
+          testSuiteName: 'suite',
+          individualTestName: 'test',
+          componentLoadTime: 10,
+          salesforceLoadTime: 20,
+          overallLoadTime: 30,
+          lwsEnabled: false,
+        },
+      ]);
+    });
+
     it('should preserve lwsEnabled=true through save and return', async () => {
       // Given
       const dto: UiTestResultDTO = {

--- a/test/database/uiTestResult.test.ts
+++ b/test/database/uiTestResult.test.ts
@@ -353,6 +353,36 @@ describe('src/database/uiTestResult', () => {
       ]);
     });
 
+    it('should exclude results where lwsEnabled is false when filtering for true', async () => {
+      // Given
+      const findStub = sinon.stub().resolves([]);
+      connectionStub.resolves({
+        manager: { find: findStub },
+      } as unknown as DataSource);
+
+      const filterOptions: UiTestResultFilterOptions = {
+        lwsEnabled: true,
+      };
+
+      // When
+      const result = await loadUiTestResults(filterOptions);
+
+      // Then
+      expect(findStub).to.be.calledWith(UiTestResult, {
+        where: [
+          {
+            createDateTime: sinon.match.any,
+            lwsEnabled: true,
+          },
+        ],
+        order: {
+          createDateTime: 'DESC',
+        },
+      });
+
+      expect(result).to.eql([]);
+    });
+
     it('should not include lwsEnabled in where clause when not provided in filter', async () => {
       // Given
       const entity = new UiTestResult();

--- a/test/database/uiTestResult.test.ts
+++ b/test/database/uiTestResult.test.ts
@@ -304,6 +304,94 @@ describe('src/database/uiTestResult', () => {
       ]);
     });
 
+    it('should filter by lwsEnabled and include 30-day filter when provided', async () => {
+      // Given
+      const entity = new UiTestResult();
+      entity.id = 5;
+      entity.testSuiteName = 'lws-suite';
+      entity.individualTestName = 'lws-test';
+      entity.componentLoadTime = 60;
+      entity.salesforceLoadTime = 140;
+      entity.overallLoadTime = 220;
+      entity.lwsEnabled = true;
+
+      const findStub = sinon.stub().resolves([entity]);
+      connectionStub.resolves({
+        manager: { find: findStub },
+      } as unknown as DataSource);
+
+      const filterOptions: UiTestResultFilterOptions = {
+        lwsEnabled: true,
+      };
+
+      // When
+      const result = await loadUiTestResults(filterOptions);
+
+      // Then
+      expect(connectionStub).to.be.calledOnce;
+      expect(findStub).to.be.calledWith(UiTestResult, {
+        where: [
+          {
+            createDateTime: sinon.match.any,
+            lwsEnabled: true,
+          },
+        ],
+        order: {
+          createDateTime: 'DESC',
+        },
+      });
+
+      expect(result).to.eql([
+        {
+          testSuiteName: 'lws-suite',
+          individualTestName: 'lws-test',
+          componentLoadTime: 60,
+          salesforceLoadTime: 140,
+          overallLoadTime: 220,
+          lwsEnabled: true,
+        },
+      ]);
+    });
+
+    it('should not include lwsEnabled in where clause when not provided in filter', async () => {
+      // Given
+      const entity = new UiTestResult();
+      entity.id = 7;
+      entity.testSuiteName = 'no-lws-filter-suite';
+      entity.individualTestName = 'no-lws-filter-test';
+      entity.componentLoadTime = 90;
+      entity.salesforceLoadTime = 180;
+      entity.overallLoadTime = 270;
+      entity.lwsEnabled = true;
+
+      const findStub = sinon.stub().resolves([entity]);
+      connectionStub.resolves({
+        manager: { find: findStub },
+      } as unknown as DataSource);
+
+      const filterOptions: UiTestResultFilterOptions = {
+        testSuiteName: 'no-lws-filter-suite',
+      };
+
+      // When
+      const result = await loadUiTestResults(filterOptions);
+
+      // Then
+      expect(findStub).to.be.calledWith(UiTestResult, {
+        where: [
+          {
+            createDateTime: sinon.match.any,
+            testSuiteName: 'no-lws-filter-suite',
+          },
+        ],
+        order: {
+          createDateTime: 'DESC',
+        },
+      });
+
+      expect(result).to.have.lengthOf(1);
+    });
+
     it('should return empty array when no matching records found within 30 days', async () => {
       // Given
       const findStub = sinon.stub().resolves([]);

--- a/test/database/uiTestResult.test.ts
+++ b/test/database/uiTestResult.test.ts
@@ -202,6 +202,46 @@ describe('src/database/uiTestResult', () => {
         },
       ]);
     });
+
+    it('should convert DTO to entities, when component and salesforce load times are provided, default to zero', async () => {
+      // Given
+      const dto: UiTestResultDTO = {
+        testSuiteName: 'suite',
+        individualTestName: 'test',
+        overallLoadTime: 30,
+        lwsEnabled: false,
+      };
+
+      const savedEntity = new UiTestResult();
+      savedEntity.id = 1;
+      savedEntity.testSuiteName = 'suite';
+      savedEntity.individualTestName = 'test';
+      savedEntity.componentLoadTime = 0;
+      savedEntity.salesforceLoadTime = 0;
+      savedEntity.overallLoadTime = 30;
+      savedEntity.lwsEnabled = false;
+
+      saveRecordsStub.resolves([savedEntity]);
+      generateValidAlertsStub.resolves([]);
+
+      // When
+      const result = await saveUiTestResult([dto]);
+
+      // Then
+      expect(saveRecordsStub).to.be.calledOnce;
+      expect(result).to.eql([
+        {
+          testSuiteName: 'suite',
+          individualTestName: 'test',
+          componentLoadTime: 0,
+          salesforceLoadTime: 0,
+          overallLoadTime: 30,
+          lwsEnabled: false,
+        },
+      ]);
+      expect(generateValidAlertsStub).to.be.calledOnce;
+      expect(alertInfoStub).to.not.be.called;
+    });
   });
 
   describe('loadUiTestResults', () => {

--- a/test/database/uiTestResult.test.ts
+++ b/test/database/uiTestResult.test.ts
@@ -419,7 +419,16 @@ describe('src/database/uiTestResult', () => {
         },
       });
 
-      expect(result).to.have.lengthOf(1);
+      expect(result).to.eql([
+        {
+          testSuiteName: 'no-lws-filter-suite',
+          individualTestName: 'no-lws-filter-test',
+          componentLoadTime: 90,
+          salesforceLoadTime: 180,
+          overallLoadTime: 270,
+          lwsEnabled: true,
+        },
+      ]);
     });
 
     it('should return empty array when no matching records found within 30 days', async () => {

--- a/test/database/uiTestResult.test.ts
+++ b/test/database/uiTestResult.test.ts
@@ -50,6 +50,7 @@ describe('src/database/uiTestResult', () => {
         componentLoadTime: 10,
         salesforceLoadTime: 20,
         overallLoadTime: 30,
+        lwsEnabled: false,
       };
 
       const savedEntity = new UiTestResult();
@@ -59,6 +60,7 @@ describe('src/database/uiTestResult', () => {
       savedEntity.componentLoadTime = 10;
       savedEntity.salesforceLoadTime = 20;
       savedEntity.overallLoadTime = 30;
+      savedEntity.lwsEnabled = false;
 
       saveRecordsStub.resolves([savedEntity]);
       generateValidAlertsStub.resolves([]);
@@ -75,6 +77,7 @@ describe('src/database/uiTestResult', () => {
           componentLoadTime: 10,
           salesforceLoadTime: 20,
           overallLoadTime: 30,
+          lwsEnabled: false,
         },
       ]);
       expect(generateValidAlertsStub).to.be.calledOnce;
@@ -89,6 +92,7 @@ describe('src/database/uiTestResult', () => {
         componentLoadTime: 10,
         salesforceLoadTime: 20,
         overallLoadTime: 30,
+        lwsEnabled: false,
       };
 
       const savedEntity = new UiTestResult();
@@ -98,6 +102,7 @@ describe('src/database/uiTestResult', () => {
       savedEntity.componentLoadTime = 10;
       savedEntity.salesforceLoadTime = 20;
       savedEntity.overallLoadTime = 30;
+      savedEntity.lwsEnabled = false;
 
       const alert: UiAlert = new UiAlert();
       alert.testSuiteName = savedEntity.testSuiteName;
@@ -118,6 +123,45 @@ describe('src/database/uiTestResult', () => {
       expect(alertInfoStub.args[0][0][0].id).to.equal(savedEntity.id);
       expect(alertInfoStub.args[0][1][0].alertType).to.equal('normal');
     });
+
+    it('should preserve lwsEnabled=true through save and return', async () => {
+      // Given
+      const dto: UiTestResultDTO = {
+        testSuiteName: 'suite',
+        individualTestName: 'test',
+        componentLoadTime: 10,
+        salesforceLoadTime: 20,
+        overallLoadTime: 30,
+        lwsEnabled: true,
+      };
+
+      const savedEntity = new UiTestResult();
+      savedEntity.id = 1;
+      savedEntity.testSuiteName = 'suite';
+      savedEntity.individualTestName = 'test';
+      savedEntity.componentLoadTime = 10;
+      savedEntity.salesforceLoadTime = 20;
+      savedEntity.overallLoadTime = 30;
+      savedEntity.lwsEnabled = true;
+
+      saveRecordsStub.resolves([savedEntity]);
+      generateValidAlertsStub.resolves([]);
+
+      // When
+      const result = await saveUiTestResult([dto]);
+
+      // Then
+      expect(result).to.eql([
+        {
+          testSuiteName: 'suite',
+          individualTestName: 'test',
+          componentLoadTime: 10,
+          salesforceLoadTime: 20,
+          overallLoadTime: 30,
+          lwsEnabled: true,
+        },
+      ]);
+    });
   });
 
   describe('loadUiTestResults', () => {
@@ -130,6 +174,7 @@ describe('src/database/uiTestResult', () => {
       entity.componentLoadTime = 100;
       entity.salesforceLoadTime = 200;
       entity.overallLoadTime = 300;
+      entity.lwsEnabled = false;
 
       const findStub = sinon.stub().resolves([entity]);
       connectionStub.resolves({
@@ -154,6 +199,7 @@ describe('src/database/uiTestResult', () => {
           componentLoadTime: 100,
           salesforceLoadTime: 200,
           overallLoadTime: 300,
+          lwsEnabled: false,
         },
       ]);
     });
@@ -167,6 +213,7 @@ describe('src/database/uiTestResult', () => {
       entity1.componentLoadTime = 50;
       entity1.salesforceLoadTime = 150;
       entity1.overallLoadTime = 200;
+      entity1.lwsEnabled = false;
 
       const findStub = sinon.stub().resolves([entity1]);
       connectionStub.resolves({
@@ -201,6 +248,7 @@ describe('src/database/uiTestResult', () => {
           componentLoadTime: 50,
           salesforceLoadTime: 150,
           overallLoadTime: 200,
+          lwsEnabled: false,
         },
       ]);
     });
@@ -214,6 +262,7 @@ describe('src/database/uiTestResult', () => {
       entity.componentLoadTime = 75;
       entity.salesforceLoadTime = 125;
       entity.overallLoadTime = 250;
+      entity.lwsEnabled = false;
 
       const findStub = sinon.stub().resolves([entity]);
       connectionStub.resolves({
@@ -250,6 +299,7 @@ describe('src/database/uiTestResult', () => {
           componentLoadTime: 75,
           salesforceLoadTime: 125,
           overallLoadTime: 250,
+          lwsEnabled: false,
         },
       ]);
     });

--- a/test/services/uiAlert.test.ts
+++ b/test/services/uiAlert.test.ts
@@ -17,6 +17,7 @@ const MOCK_TEST_DTO_BASE: UiTestResultDTO = {
   overallLoadTime: 1000,
   componentLoadTime: 500,
   salesforceLoadTime: 500,
+  lwsEnabled: false,
   alertInfo: undefined,
 } as UiTestResultDTO;
 
@@ -115,7 +116,7 @@ describe('generateValidAlerts', () => {
         },
       };
       checkRecentStub.resolves(
-        new Set(['ComponentLoadSuite_ComponentXLoadTime'])
+        new Set(['ComponentLoadSuite_ComponentXLoadTime_false'])
       );
       getAveragesStub.resolves(mockAverages);
 
@@ -137,6 +138,28 @@ describe('generateValidAlerts', () => {
         },
       };
       checkRecentStub.resolves(new Set());
+      getAveragesStub.resolves(mockAverages);
+
+      // When
+      const results = await generateValidAlerts([MOCK_TEST_DTO_BASE]);
+
+      // Then
+      expect(results).to.have.lengthOf(1);
+      expect(getAveragesStub).to.have.been.called;
+    });
+
+    it('should not suppress an alert for lwsEnabled=false when a recent alert exists only for lwsEnabled=true', async () => {
+      // Given
+      const avgNext10 = 100;
+      const mockAverages = {
+        ['ComponentLoadSuite_ComponentXLoadTime']: {
+          avg_load_time_past_5_days: avgFirst5,
+          avg_load_time_6_to_15_days_ago: avgNext10,
+        },
+      };
+      checkRecentStub.resolves(
+        new Set(['ComponentLoadSuite_ComponentXLoadTime_true'])
+      );
       getAveragesStub.resolves(mockAverages);
 
       // When

--- a/test/services/uiAlert.test.ts
+++ b/test/services/uiAlert.test.ts
@@ -152,7 +152,7 @@ describe('generateValidAlerts', () => {
       // Given
       const avgNext10 = 100;
       const mockAverages = {
-        ['ComponentLoadSuite_ComponentXLoadTime']: {
+        ['ComponentLoadSuite_ComponentXLoadTime_false']: {
           avg_load_time_past_5_days: avgFirst5,
           avg_load_time_6_to_15_days_ago: avgNext10,
         },
@@ -246,7 +246,7 @@ describe('generateValidAlerts', () => {
     it('should return NO alert when result is an improvement (recent avg is lower than historical avg)', async () => {
       // Given
       const mockAverages = {
-        ['ComponentLoadSuite_ComponentXLoadTime']: {
+        ['ComponentLoadSuite_ComponentXLoadTime_false']: {
           avg_load_time_past_5_days: 100,
           avg_load_time_6_to_15_days_ago: 200,
         },

--- a/test/services/uiAlert.test.ts
+++ b/test/services/uiAlert.test.ts
@@ -220,23 +220,6 @@ describe('generateValidAlerts', () => {
       expect(results).to.be.an('array').that.is.empty;
     });
 
-    it('should return NO alert when result is an improvement (recent avg is lower than historical avg)', async () => {
-      // Given - recent 5 days avg is LOWER (faster) than 6-15 days ago avg
-      const mockAverages = {
-        ['ComponentLoadSuite_ComponentXLoadTime']: {
-          avg_load_time_past_5_days: 100,
-          avg_load_time_6_to_15_days_ago: 200,
-        },
-      };
-      getAveragesStub.resolves(mockAverages);
-
-      // When
-      const results = await generateValidAlerts([MOCK_TEST_DTO_BASE]);
-
-      // Then
-      expect(results).to.be.an('array').that.is.empty;
-    });
-
     it('should return NO alert if degradation is zero', async () => {
       //Given
       const avgNext10 = 200;

--- a/test/services/uiAlert.test.ts
+++ b/test/services/uiAlert.test.ts
@@ -109,13 +109,13 @@ describe('generateValidAlerts', () => {
       // Given
       const avgNext10 = 100;
       const mockAverages = {
-        ['ComponentLoadSuite_ComponentXLoadTime']: {
+        ['ComponentLoadSuite_ComponentXLoadTime_false']: {
           avg_load_time_past_5_days: avgFirst5,
           avg_load_time_6_to_15_days_ago: avgNext10,
         },
       };
       checkRecentStub.resolves(
-        new Set(['ComponentLoadSuite_ComponentXLoadTime'])
+        new Set(['ComponentLoadSuite_ComponentXLoadTime_false'])
       );
       getAveragesStub.resolves(mockAverages);
 

--- a/test/services/uiAlert.test.ts
+++ b/test/services/uiAlert.test.ts
@@ -131,7 +131,7 @@ describe('generateValidAlerts', () => {
       // Given
       const avgNext10 = 100;
       const mockAverages = {
-        ['ComponentLoadSuite_ComponentXLoadTime']: {
+        ['ComponentLoadSuite_ComponentXLoadTime_false']: {
           avg_load_time_past_5_days: avgFirst5,
           avg_load_time_6_to_15_days_ago: avgNext10,
         },
@@ -155,7 +155,7 @@ describe('generateValidAlerts', () => {
       //Given
       const avgNext10 = 100;
       const mockAverages = {
-        ['ComponentLoadSuite_ComponentXLoadTime']: {
+        ['ComponentLoadSuite_ComponentXLoadTime_false']: {
           avg_load_time_past_5_days: avgFirst5,
           avg_load_time_6_to_15_days_ago: avgNext10,
         },
@@ -175,7 +175,7 @@ describe('generateValidAlerts', () => {
       //Given
       const avgNext10 = 165;
       const mockAverages = {
-        ['ComponentLoadSuite_ComponentXLoadTime']: {
+        ['ComponentLoadSuite_ComponentXLoadTime_false']: {
           avg_load_time_past_5_days: avgFirst5,
           avg_load_time_6_to_15_days_ago: avgNext10,
         },
@@ -195,7 +195,7 @@ describe('generateValidAlerts', () => {
       // Given
       const avgNext10 = 185;
       const mockAverages = {
-        ['ComponentLoadSuite_ComponentXLoadTime']: {
+        ['ComponentLoadSuite_ComponentXLoadTime_false']: {
           avg_load_time_past_5_days: avgFirst5,
           avg_load_time_6_to_15_days_ago: avgNext10,
         },
@@ -224,7 +224,7 @@ describe('generateValidAlerts', () => {
       //Given
       const avgNext10 = 200;
       const mockAverages = {
-        ['ComponentLoadSuite_ComponentXLoadTime']: {
+        ['ComponentLoadSuite_ComponentXLoadTime_false']: {
           avg_load_time_past_5_days: avgFirst5,
           avg_load_time_6_to_15_days_ago: avgNext10,
         },
@@ -246,7 +246,7 @@ describe('generateValidAlerts', () => {
 
     const avgNext10 = 175;
     const mockAverages = {
-      ['ComponentLoadSuite_ComponentXLoadTime']: {
+      ['ComponentLoadSuite_ComponentXLoadTime_false']: {
         avg_load_time_past_5_days: 200,
         avg_load_time_6_to_15_days_ago: avgNext10,
       },

--- a/test/services/uiAlert.test.ts
+++ b/test/services/uiAlert.test.ts
@@ -221,7 +221,7 @@ describe('generateValidAlerts', () => {
     });
 
     it('should return NO alert when result is an improvement (recent avg is lower than historical avg)', async () => {
-      // Given - recent 5 days avg is LOWER (faster) than 6-15 days ago avg
+      // Given
       const mockAverages = {
         ['ComponentLoadSuite_ComponentXLoadTime']: {
           avg_load_time_past_5_days: 100,

--- a/test/services/uiAlert.test.ts
+++ b/test/services/uiAlert.test.ts
@@ -220,6 +220,23 @@ describe('generateValidAlerts', () => {
       expect(results).to.be.an('array').that.is.empty;
     });
 
+    it('should return NO alert when result is an improvement (recent avg is lower than historical avg)', async () => {
+      // Given - recent 5 days avg is LOWER (faster) than 6-15 days ago avg
+      const mockAverages = {
+        ['ComponentLoadSuite_ComponentXLoadTime']: {
+          avg_load_time_past_5_days: 100,
+          avg_load_time_6_to_15_days_ago: 200,
+        },
+      };
+      getAveragesStub.resolves(mockAverages);
+
+      // When
+      const results = await generateValidAlerts([MOCK_TEST_DTO_BASE]);
+
+      // Then
+      expect(results).to.be.an('array').that.is.empty;
+    });
+
     it('should return NO alert if degradation is zero', async () => {
       //Given
       const avgNext10 = 200;


### PR DESCRIPTION
Enable tracking of whether UI tests were run with Lightning Web Security (LWS) enabled or disabled. This requires adding a new `lws_enabled` boolean field across the database, entities, DTOs, query logic, alert generation, and tests. Existing records default to false (LWS off).