### PR TITLE
Bump version to 7.1.0 and add database subpath export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Benchmarker - Changelog
 
+## 7.1.0
+
+- Add `database` subpath export to allow direct imports from `@apexdevtools/benchmarker/database`.
+
 ## 7.0.0
 
 - Add LWS (Lightning Web Security) Tracking to UI Test Results & Alerts.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@apexdevtools/benchmarker",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@apexdevtools/benchmarker",
-      "version": "7.0.0",
+      "version": "7.1.0",
       "dependencies": {
         "@jsforce/jsforce-node": "3.2.0",
         "@salesforce/core": "7.3.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apexdevtools/benchmarker",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Benchmarks performance of processes on Salesforce Orgs",
   "author": {
     "name": "Apex Dev Tools Team",
@@ -11,6 +11,16 @@
   "homepage": "https://github.com/apex-dev-tools/benchmarker",
   "main": "dist/src/index.js",
   "types": "dist/types/src/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/types/src/index.d.ts",
+      "default": "./dist/src/index.js"
+    },
+    "./database": {
+      "types": "./dist/types/src/database/index.d.ts",
+      "default": "./dist/src/database/index.js"
+    }
+  },
   "files": [
     "db/migrations",
     "dist/src",

--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -1,0 +1,14 @@
+/**
+ * @copyright 2026 Certinia Inc. All rights reserved.
+ */
+
+export {
+  saveUiTestResult,
+  loadUiTestResults,
+  UiAlertInfo,
+  UiAlertThresholds,
+} from './uiTestResult';
+export type {
+  UiTestResultDTO,
+  UiTestResultFilterOptions,
+} from './uiTestResult';


### PR DESCRIPTION
Currently, importing anything from {{@apexdevtools/benchmarker}} pulls in all transitive dependencies — including {{[@Salesforce](https://certinia.enterprise.slack.com/team/U06C4A7ALTW)/core}} (~1.4 MB) and {{@jsforce/jsforce-node}} (~4.4 MB) — because the main {{index.ts}} imports {{services/salesforce/*}} at the module level.

Consumers such as Artillery-based UI performance tests only need {{saveUiTestResult}} and {{UiTestResultDTO}}, which have no Salesforce dependencies in their call chain (TypeORM + pg only). Bundling the entire package for these consumers causes {{RangeError: Invalid array length}} in {{esbuild-wasm}} due to WASM memory constraints.