### PR TITLE
[codex] Average transaction process runs

### DIFF
--- a/src/testTemplates/transactionTestTemplate.ts
+++ b/src/testTemplates/transactionTestTemplate.ts
@@ -116,17 +116,21 @@ export interface TestFlowOptions {
 
 const DEFAULT_RUN_COUNT = 1;
 
-const governorMetricKeys: Array<keyof GovernorMetricsResult> = [
-  'timer',
-  'cpuTime',
-  'dmlRows',
-  'dmlStatements',
-  'heapSize',
-  'queryRows',
-  'soqlQueries',
-  'queueableJobs',
-  'futureCalls',
-];
+const FAILED_GOVERNOR_METRICS_RESULT: GovernorMetricsResult = {
+  cpuTime: -1,
+  dmlRows: -1,
+  dmlStatements: -1,
+  heapSize: -1,
+  queryRows: -1,
+  soqlQueries: -1,
+  queueableJobs: -1,
+  futureCalls: -1,
+  timer: -1,
+};
+
+const governorMetricKeys = Object.keys(FAILED_GOVERNOR_METRICS_RESULT) as Array<
+  keyof GovernorMetricsResult
+>;
 
 const resolveExecutionOptions = (
   alertInfoOrRunCount?: AlertInfo | number,
@@ -143,7 +147,7 @@ const resolveExecutionOptions = (
 };
 
 const validateRunCount = (runCount: number): void => {
-  if (!Number.isInteger(runCount) || runCount < DEFAULT_RUN_COUNT) {
+  if (!Number.isInteger(runCount) || runCount < 1) {
     throw new RangeError(
       'runCount must be an integer greater than or equal to 1'
     );
@@ -222,17 +226,7 @@ export namespace TransactionProcess {
         processTestTemplate.flowStepsResults.push({
           testStepDescription: e.testStepDescription,
           error: e.message,
-          result: {
-            cpuTime: -1,
-            dmlRows: -1,
-            dmlStatements: -1,
-            heapSize: -1,
-            queryRows: -1,
-            soqlQueries: -1,
-            queueableJobs: -1,
-            futureCalls: -1,
-            timer: -1,
-          },
+          result: { ...FAILED_GOVERNOR_METRICS_RESULT },
         });
       } else {
         throw e;

--- a/src/testTemplates/transactionTestTemplate.ts
+++ b/src/testTemplates/transactionTestTemplate.ts
@@ -164,7 +164,7 @@ const averageResults = (results: TestFlowOutput[]): TestFlowOutput => {
   }, {} as GovernorMetricsResult);
 
   return {
-    ...firstResult,
+    testStepDescription: firstResult.testStepDescription,
     result: averageMetrics,
   };
 };

--- a/src/testTemplates/transactionTestTemplate.ts
+++ b/src/testTemplates/transactionTestTemplate.ts
@@ -114,6 +114,57 @@ export interface TestFlowOptions {
   tokenMap?: TokenReplacement[];
 }
 
+const DEFAULT_RUN_COUNT = 1;
+
+const governorMetricKeys: Array<keyof GovernorMetricsResult> = [
+  'timer',
+  'cpuTime',
+  'dmlRows',
+  'dmlStatements',
+  'heapSize',
+  'queryRows',
+  'soqlQueries',
+  'queueableJobs',
+  'futureCalls',
+];
+
+const resolveExecutionOptions = (
+  alertInfoOrRunCount?: AlertInfo | number,
+  runCount?: number
+): { alertInfo?: AlertInfo; runCount: number } => {
+  if (typeof alertInfoOrRunCount === 'number') {
+    return { runCount: alertInfoOrRunCount };
+  }
+
+  return {
+    alertInfo: alertInfoOrRunCount,
+    runCount: runCount ?? DEFAULT_RUN_COUNT,
+  };
+};
+
+const validateRunCount = (runCount: number): void => {
+  if (!Number.isInteger(runCount) || runCount < DEFAULT_RUN_COUNT) {
+    throw new RangeError(
+      'runCount must be an integer greater than or equal to 1'
+    );
+  }
+};
+
+const averageResults = (results: TestFlowOutput[]): TestFlowOutput => {
+  const [firstResult] = results;
+
+  const averageMetrics = governorMetricKeys.reduce((acc, key) => {
+    const total = results.reduce((sum, output) => sum + output.result[key], 0);
+    acc[key] = Math.round(total / results.length);
+    return acc;
+  }, {} as GovernorMetricsResult);
+
+  return {
+    ...firstResult,
+    result: averageMetrics,
+  };
+};
+
 export namespace TransactionProcess {
   /**
    * Sets the configuration for the Test Template
@@ -142,15 +193,29 @@ export namespace TransactionProcess {
    * Executes Apex code from a file and retrieve the Governor Limits
    * @param processTestTemplate object with all the information required to execute a test
    * @param testStep list of test steps to be executed
+   * @param alertInfoOrRunCount alert configuration, or number of runs to execute and average
+   * @param runCount number of runs to execute and average when alert info is provided
    */
   export const executeTestStep = async (
     processTestTemplate: TransactionTestTemplate,
     testStep: FlowStep,
-    alertInfo?: AlertInfo
+    alertInfoOrRunCount?: AlertInfo | number,
+    runCount?: number
   ) => {
+    const executionOptions = resolveExecutionOptions(
+      alertInfoOrRunCount,
+      runCount
+    );
+    validateRunCount(executionOptions.runCount);
+
     try {
-      const result: TestFlowOutput = await testStep();
-      result.alertInfo = alertInfo;
+      const results: TestFlowOutput[] = [];
+      for (let i = 0; i < executionOptions.runCount; i++) {
+        results.push(await testStep());
+      }
+
+      const result: TestFlowOutput = averageResults(results);
+      result.alertInfo = executionOptions.alertInfo;
       processTestTemplate.flowStepsResults.push(result);
     } catch (e) {
       if (e.testStepDescription) {

--- a/test/testTemplates/transactionTestTemplate.test.ts
+++ b/test/testTemplates/transactionTestTemplate.test.ts
@@ -160,6 +160,153 @@ describe('src/testTemplates/transactionTestTemplate', () => {
       expect((thresholds as Thresholds).soqlQueriesThreshold).to.be.equal(6);
     });
 
+    it('runs a test step multiple times and saves a single averaged result', async () => {
+      // Given
+      stub(utils, 'sobject').returns({
+        create: stub(),
+      });
+
+      // When
+      const test: TransactionTestTemplate =
+        await TransactionProcess.build(MOCKPRODUCT_FULLNAME);
+      const flowStep = stub();
+      flowStep.onFirstCall().resolves({
+        testStepDescription: {
+          action: 'Mock action',
+          flowName: 'Mock flow name',
+        },
+        result: {
+          timer: 10,
+          cpuTime: 20,
+          dmlRows: 30,
+          dmlStatements: 40,
+          heapSize: 50,
+          queryRows: 60,
+          soqlQueries: 70,
+          queueableJobs: 80,
+          futureCalls: 90,
+        },
+      });
+      flowStep.onSecondCall().resolves({
+        testStepDescription: {
+          action: 'Mock action',
+          flowName: 'Mock flow name',
+        },
+        result: {
+          timer: 20,
+          cpuTime: 30,
+          dmlRows: 40,
+          dmlStatements: 50,
+          heapSize: 60,
+          queryRows: 70,
+          soqlQueries: 80,
+          queueableJobs: 90,
+          futureCalls: 100,
+        },
+      });
+      flowStep.onThirdCall().resolves({
+        testStepDescription: {
+          action: 'Mock action',
+          flowName: 'Mock flow name',
+        },
+        result: {
+          timer: 30,
+          cpuTime: 40,
+          dmlRows: 50,
+          dmlStatements: 60,
+          heapSize: 70,
+          queryRows: 80,
+          soqlQueries: 90,
+          queueableJobs: 100,
+          futureCalls: 110,
+        },
+      });
+
+      await TransactionProcess.executeTestStep(test, flowStep, 3);
+
+      // Then
+      expect(flowStep).to.have.been.calledThrice;
+      expect(test.flowStepsResults).to.have.length(1);
+      expect(test.flowStepsResults[0].result.timer).to.be.equal(20);
+      expect(test.flowStepsResults[0].result.cpuTime).to.be.equal(30);
+      expect(test.flowStepsResults[0].result.dmlRows).to.be.equal(40);
+      expect(test.flowStepsResults[0].result.dmlStatements).to.be.equal(50);
+      expect(test.flowStepsResults[0].result.heapSize).to.be.equal(60);
+      expect(test.flowStepsResults[0].result.queryRows).to.be.equal(70);
+      expect(test.flowStepsResults[0].result.soqlQueries).to.be.equal(80);
+      expect(test.flowStepsResults[0].result.queueableJobs).to.be.equal(90);
+      expect(test.flowStepsResults[0].result.futureCalls).to.be.equal(100);
+    });
+
+    it('runs a test step multiple times with alert info', async () => {
+      // Given
+      stub(utils, 'sobject').returns({
+        create: stub(),
+      });
+
+      // When
+      const test: TransactionTestTemplate =
+        await TransactionProcess.build(MOCKPRODUCT_FULLNAME);
+      const result: TestFlowOutput = {
+        testStepDescription: {
+          action: 'Mock action',
+          flowName: 'Mock flow name',
+        },
+        result: {
+          timer: 1,
+          cpuTime: 2,
+          dmlRows: 3,
+          dmlStatements: 4,
+          heapSize: 5,
+          queryRows: 6,
+          soqlQueries: 7,
+          queueableJobs: 8,
+          futureCalls: 9,
+        },
+      };
+      const alertInfo: AlertInfo = {
+        storeAlerts: true,
+        thresholds: {
+          cpuTimeThreshold: 1,
+          dmlStatementThreshold: 2,
+          dmlRowThreshold: 3,
+          heapSizeThreshold: 4,
+          queryRowsThreshold: 5,
+          soqlQueriesThreshold: 6,
+        },
+      };
+      const flowStep: FlowStep = stub().resolves(result);
+
+      await TransactionProcess.executeTestStep(test, flowStep, alertInfo, 2);
+
+      // Then
+      expect(flowStep).to.have.been.calledTwice;
+      expect(test.flowStepsResults).to.have.length(1);
+      expect(test.flowStepsResults[0].alertInfo).to.be.equal(alertInfo);
+    });
+
+    it('throws when run count is less than one', async () => {
+      // Given
+      stub(utils, 'sobject').returns({
+        create: stub(),
+      });
+      const test: TransactionTestTemplate =
+        await TransactionProcess.build(MOCKPRODUCT_FULLNAME);
+      const flowStep: FlowStep = stub().resolves();
+
+      // When
+      try {
+        await TransactionProcess.executeTestStep(test, flowStep, 0);
+        expect.fail('Expected an error to be thrown');
+      } catch (error) {
+        // Then
+        expect(error).to.be.instanceof(RangeError);
+        expect((error as Error).message).to.equal(
+          'runCount must be an integer greater than or equal to 1'
+        );
+      }
+    });
+
     it('fails and save the result as status is failed', async () => {
       // Given
       stub(utils, 'sobject').returns({


### PR DESCRIPTION
## Summary
- Add optional run-count support to TransactionProcess.executeTestStep
- Average governor metrics into one stored result across repeated runs
- Preserve existing alertInfo usage and add focused unit coverage

## Issue
Closes #15

## Validation
- npm run compile
- npm test