### PR TITLE
[codex] Update GitHub automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+version: 2
+
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    groups:
+      npm-minor-patch:
+        update-types: ["minor", "patch"]
+    ignore:
+      # @types/node tracks the Node runtime version; pin to the configured
+      # build runtime rather than chasing current Node majors.
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    groups:
+      actions:
+        patterns: ["*"]

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -12,13 +12,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
 
-      - name: Set up Node LTS
-        uses: actions/setup-node@v3
+      - name: Set up Node
+        uses: actions/setup-node@v6
         with:
-          node-version: 'lts/*'
-          cache: 'npm'
+          node-version: 22
+          cache: "npm"
 
       - name: Install
         run: npm ci

--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -9,18 +9,25 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
 
-      - name: Set up Node LTS
-        uses: actions/setup-node@v3
+      - name: Set up Node
+        uses: actions/setup-node@v6
         with:
-          node-version: 'lts/*'
-          registry-url: 'https://registry.npmjs.org'
+          node-version: 22
+          registry-url: "https://registry.npmjs.org"
 
       - name: Publish package
         run: |
           npm ci
           npm run build
-          npm publish --access public
+          VERSION=$(node -p "require('./package.json').version")
+          if [[ "$VERSION" == *-* ]]; then
+            echo "Publishing $VERSION under dist-tag 'beta'"
+            npm publish --access public --tag beta
+          else
+            echo "Publishing $VERSION under dist-tag 'latest'"
+            npm publish --access public
+          fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- Update GitHub Actions workflows to the newer checkout/setup-node actions and Node 22 runtime
- Keep npm install caching on the build workflow
- Add prerelease-aware npm publishing so prerelease versions publish with the beta dist-tag
- Add Dependabot coverage for npm and GitHub Actions updates

## Context
Mirrors the recent automation style used in apex-dev-tools/apex-parser, adjusted for this npm-only repository.

## Validation
- Parsed Build.yml, Publish.yml, and dependabot.yml with Ruby YAML