### PR TITLE
[codex] Fix TypeScript 6 test runner

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "doc:generate": "typedoc --out docs/api ./src",
     "lint": "eslint ./src ./test ./test_system --fix",
     "prepare": "ts-patch install -s && husky",
-    "test": "nyc mocha --timeout 10000 'test/**/*.test.*'",
+    "test": "TS_NODE_TRANSPILE_ONLY=true TS_NODE_COMPILER_OPTIONS='{\"ignoreDeprecations\":\"6.0\",\"rootDir\":\".\",\"types\":[\"node\",\"mocha\"]}' NODE_OPTIONS='--loader ts-node/esm --experimental-specifier-resolution=node' nyc mocha --timeout 10000 'test/**/*.test.*'",
     "test:only": "nyc mocha --timeout 10000",
     "test:system:init": "cp test_system/.env .env",
     "test:system": "mocha --timeout 30000 'test_system/**/*.test.*'"


### PR DESCRIPTION
## Summary
- Runs Mocha tests through the ts-node ESM loader when using TypeScript 6.
- Sets ts-node test-time compiler options explicitly so the suite can resolve existing extensionless TypeScript imports.
- Keeps npm run build as the typechecking step; tests run transpile-only as runtime-focused nyc/mocha tests.

## Root Cause
With TypeScript 6, Mocha loads TypeScript test files through Node's ESM import path, and Node cannot resolve existing extensionless imports such as src/database/alertInfo. The old ts-node/register CommonJS hook is not reached early enough to resolve those imports.

## Validation
- npm ci
- npm run build
- npm test starts and executes the suite: 257 passing, 19 pending locally. The remaining local failures are sandbox-specific Salesforce CLI log writes to /Users/kevinjones/.sf, not the prior ERR_MODULE_NOT_FOUND startup failure.