### PR TITLE
chore: release 7.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Benchmarker - Changelog
 
+## 7.2.0
+
+- Average `TransactionProcess` runs for short-running transactions to reduce noise from single-run variance, without carrying first-run-only fields into the averaged result.
+- Update Lighthouse to 13.4.0.
+- Dependency and tooling maintenance: TypeScript 6, mocha 11, nyc 18, updated ESLint tooling, and fixes for vulnerable dependencies.
+
 ## 7.1.1
 
 - Fix UI alert false positives caused by a NULL baseline average being silently coerced to zero when no data existed in the 6-to-15-day window.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@apexdevtools/benchmarker",
-  "version": "7.1.1",
+  "version": "7.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@apexdevtools/benchmarker",
-      "version": "7.1.1",
+      "version": "7.2.0",
       "dependencies": {
         "@jsforce/jsforce-node": "3.10.18",
         "@salesforce/core": "7.3.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apexdevtools/benchmarker",
-  "version": "7.1.1",
+  "version": "7.2.0",
   "description": "Benchmarks performance of processes on Salesforce Orgs",
   "author": {
     "name": "Apex Dev Tools Team",


### PR DESCRIPTION
Prepares the 7.2.0 release. `main` was 30 commits ahead of the `v7.1.1` tag with no version bump; this cuts that accumulated work as 7.2.0.

## Changes
- Bump version `7.1.1` → `7.2.0` (`package.json`, `package-lock.json`).
- Add `## 7.2.0` CHANGELOG section.

## What's in this release
- **Feature:** average `TransactionProcess` runs for short-running transactions to reduce single-run variance (PR #62).
- Dependency/tooling maintenance: Lighthouse 12→13.4.0, TypeScript 5.4→6, mocha 10→11, nyc 15→18, ESLint tooling, vulnerable-dependency fixes.

Minor bump per the project's convention (features → minor, matching 7.1.0). No apex-dev-tools library dependencies, so nothing to pin here — independent of the play-cli/apex-flow release wave.

After merge: create the `v7.2.0` GitHub Release to trigger the Publish workflow (public npm via `NPM_TOKEN` — no Artifactory/mTLS path involved).