### PR TITLE
Reduce disabled ESLint rules

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -27,39 +27,46 @@ module.exports = [
     ],
     rules: {
       'prettier/prettier': 'warn',
+      // The node plugin does not understand this repo's TS path/transformer setup.
       'n/no-missing-import': 'off',
       'n/no-empty-function': 'off',
       'n/no-unsupported-features/es-syntax': 'off',
       'n/no-missing-require': 'off',
       'n/shebang': 'off',
       '@typescript-eslint/no-unused-vars': 'warn',
+      // Existing test/helper structure still has declaration-order dependencies.
       '@typescript-eslint/no-use-before-define': 'off',
       quotes: ['warn', 'single', { avoidEscape: true }],
+      // Tests and build-time transformer inputs import files outside published package paths.
       'n/no-unpublished-import': 'off',
+      // Existing Salesforce/JSForce and test-helper boundaries use broad untyped values.
       '@typescript-eslint/no-unsafe-assignment': 'off',
       '@typescript-eslint/no-var-requires': 'off',
       '@typescript-eslint/ban-ts-comment': 'off',
       '@typescript-eslint/no-explicit-any': 'off',
 
-      // temp disabled - currently errors on this codebase
+      // Existing namespace and unsafe-value usage needs a larger type-tightening pass.
       '@typescript-eslint/no-namespace': 'off',
       '@typescript-eslint/no-unsafe-argument': 'off',
       '@typescript-eslint/no-unsafe-member-access': 'off',
       '@typescript-eslint/no-unsafe-return': 'off',
       '@typescript-eslint/no-unsafe-call': 'off',
+      // Chai's fluent assertion style needs a test-specific rule configuration.
       '@typescript-eslint/no-unused-expressions': 'off',
+      // Async and promise/error rules need behavioral review before broad enablement.
       '@typescript-eslint/require-await': 'off',
       '@typescript-eslint/no-misused-promises': 'off',
-      '@typescript-eslint/only-throw-error': 'off',
+      '@typescript-eslint/only-throw-error': 'error',
       '@typescript-eslint/prefer-promise-reject-errors': 'off',
-      '@typescript-eslint/no-require-imports': 'off',
+      '@typescript-eslint/no-require-imports': 'error',
       '@typescript-eslint/restrict-template-expressions': 'off',
       '@typescript-eslint/unbound-method': 'off',
+      // Remaining core rule disables require focused code cleanup passes.
       'no-async-promise-executor': 'off',
       'no-useless-escape': 'off',
       'no-case-declarations': 'off',
-      'no-useless-assignment': 'off',
-      'preserve-caught-error': 'off',
+      'no-useless-assignment': 'error',
+      'preserve-caught-error': 'error',
     },
   }),
 ];

--- a/src/services/filesystem.ts
+++ b/src/services/filesystem.ts
@@ -90,7 +90,7 @@ const createDir = async (directoryName: string): Promise<string> =>
   exists(directoryName)
     .then((existsFolder: boolean) => {
       if (!existsFolder) return directoryName;
-      else throw { error: `Already exists ${directoryName}` };
+      else throw new Error(`Already exists ${directoryName}`);
     })
     .then((_directoryName: string) => mkdirCustomMode(_directoryName))
     .then(() => directoryName);

--- a/src/services/org/packages.ts
+++ b/src/services/org/packages.ts
@@ -25,7 +25,7 @@ export async function getPackagesOnOrg(
     SubscriberPackageVersion,
   } of packageData.records) {
     const packageName: string = SubscriberPackage.Name;
-    let packageVersion: string = '';
+    let packageVersion: string;
     let isBeta: boolean = false;
     let betaName: number = DEFAULT_NUMERIC_VALUE;
 

--- a/src/services/salesforce/connection.ts
+++ b/src/services/salesforce/connection.ts
@@ -110,8 +110,11 @@ export async function connectToSalesforceOrg(
       throw new Error('Password is required for non-SFDX login');
     }
   } catch (e) {
-    throw new Error(
-      `Exception happened in the Salesforce authentication process. Exception message: ${e}`
+    throw Object.assign(
+      new Error(
+        `Exception happened in the Salesforce authentication process. Exception message: ${e}`
+      ),
+      { cause: e }
     );
   }
 

--- a/src/services/salesforce/data.ts
+++ b/src/services/salesforce/data.ts
@@ -259,8 +259,8 @@ const insertDataWithBatches = async (
   return batchExecutionResults;
 };
 const insertChunk = (job: Job<Schema, BulkOperation>, chunkedData: any[]) => {
-  let batchJob = job.createBatch();
-  return (batchJob = batchJob.execute(chunkedData));
+  const batchJob = job.createBatch();
+  return batchJob.execute(chunkedData);
 };
 function getBulkBatchExecution(batchResults: BulkIngestBatchResult): {
   failed: boolean;

--- a/src/testTemplates/testStepFlowHelper.ts
+++ b/src/testTemplates/testStepFlowHelper.ts
@@ -24,6 +24,7 @@ export const createApexExecutionTestStepFlow = async (
   testStepDescription: TestStepDescription,
   testFlowOptions?: TestFlowOptions
 ): Promise<FlowStep> => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports -- The Apex transformer inlines require('*.apex') calls at compile time.
   const governorMetricsApexClass = require('./apex/GovernorLimits.apex');
   const originalApexFileContent = await readFile(apexScriptPath);
   const processedApexFileContent = replaceTokensInString(

--- a/test/shared/timer.test.ts
+++ b/test/shared/timer.test.ts
@@ -42,13 +42,13 @@ describe('src/scenario/shared/timer', () => {
     const testTimer: Timer = new Timer('Test');
 
     const startTime = moment('2010-01-01 10:30:35', 'YYYY-MM-DD HH:mm:ss');
-    let momentStub = stub(moment, 'now').returns(startTime.unix() * 1000);
+    const momentStub = stub(moment, 'now').returns(startTime.unix() * 1000);
     testTimer.start();
 
     momentStub.restore();
 
     const endTime = moment('2015-02-02 11:40:45', 'YYYY-MM-DD HH:mm:ss');
-    momentStub = stub(moment, 'now').returns(endTime.unix() * 1000);
+    stub(moment, 'now').returns(endTime.unix() * 1000);
     testTimer.end();
 
     expect(testTimer.getTime()).to.eql(endTime.diff(startTime));

--- a/test_system/database.ts
+++ b/test_system/database.ts
@@ -11,7 +11,9 @@ export async function cleanDatabase(): Promise<void> {
 
     await connection.query(`TRUNCATE ${tableNames} CASCADE;`);
   } catch (error) {
-    throw new Error(`ERROR: Cleaning test database: ${error}`);
+    throw Object.assign(new Error(`ERROR: Cleaning test database: ${error}`), {
+      cause: error,
+    });
   }
 }
 
@@ -37,8 +39,9 @@ export async function getAlerts(
         AND action='${action_name}'`
     );
   } catch (error) {
-    throw new Error(
-      `ERROR: Getting the alerts from database. ${error.message}`
+    throw Object.assign(
+      new Error(`ERROR: Getting the alerts from database. ${error.message}`),
+      { cause: error }
     );
   }
 }


### PR DESCRIPTION
## Summary

Closes #72.

This reduces the ESLint disabled-rule list by re-enabling four focused rules:

- `@typescript-eslint/only-throw-error`
- `@typescript-eslint/no-require-imports`
- `no-useless-assignment`
- `preserve-caught-error`

The related code changes replace a thrown plain object with `Error`, remove useless temporary assignments, and preserve caught errors as `cause` without requiring a newer TypeScript `Error` constructor overload.

The one remaining `require('*.apex')` call now has a targeted inline exception because the repo's TS transformer specifically inlines Apex source from `require()` calls. The broader config disable is no longer needed.

The remaining disabled-rule groups now have short rationale comments in `eslint.config.js`, so future cleanup work has clearer boundaries.

## Verification

- `npm run lint`
- `npm run build`
- `npm test` passed with elevated filesystem access for Salesforce CLI logs under `~/.sf`

`npm run lint` still reports the pre-existing six `@typescript-eslint/no-unused-vars` warnings, but no errors.
